### PR TITLE
Feat/질문기록 탭에서의 답변,피드백 기능 추가

### DIFF
--- a/src/api/mocks/handlers/project.ts
+++ b/src/api/mocks/handlers/project.ts
@@ -30,13 +30,18 @@ export interface CSQuestion {
 // 질문 이력 아이템 타입
 export interface QuestionHistoryItem {
   id: number
-  csQuestionId?: number // API 응답에서 사용될 수 있는 필드
   question: string
-  answer: string
-  feedback: string
-  codeSnippet: string
+  codeSnippet?: string
+  fileName?: string
+  status?: string
+  // API 응답에서 가능한 필드
+  csQuestionId?: number
+  answer?: string
+  feedback?: string
   answered?: boolean
-  status?: 'Todo' | 'Done'
+  concept?: string
+  date?: string
+  userCode?: string
 }
 
 // 날짜별 질문 이력 타입

--- a/src/api/services/project.ts
+++ b/src/api/services/project.ts
@@ -120,14 +120,14 @@ export const getProjectFiles = async (
  */
 export const getFileCode = async (
   projectId: string,
-  fileName: string,
+  folderName: string,
 ): Promise<string> => {
   try {
     // GitHub 저장소 정보 가져오기
     const { owner, repo, branch } = await getGitHubRepoInfo(projectId)
 
     // GitHub API를 사용하여 파일 내용 가져오기
-    const content = await fetchGitHubFile(owner, repo, fileName, branch)
+    const content = await fetchGitHubFile(owner, repo, folderName, branch)
 
     return content
   } catch (error) {
@@ -142,7 +142,7 @@ export const getFileCode = async (
 export const generateCSQuestions = async (
   projectId: string,
   code: string,
-  fileName: string,
+  folderName: string,
 ): Promise<CSQuestion[]> => {
   try {
     const response = await fetcher<{
@@ -156,7 +156,7 @@ export const generateCSQuestions = async (
         body: JSON.stringify({
           projectId,
           userCode: code,
-          fileName,
+          folderName,
         }),
       },
       true,

--- a/src/api/services/question/generate.ts
+++ b/src/api/services/question/generate.ts
@@ -23,7 +23,7 @@ export const useCreateProjectCsQuestion = () => {
 export const generateCSQuestions = async (
   projectId: string,
   code: string,
-  fileName: string,
+  folderName: string,
 ): Promise<CSQuestion[]> => {
   try {
     const data = await fetcher<{ result: any[] }>(
@@ -33,7 +33,7 @@ export const generateCSQuestions = async (
         body: JSON.stringify({
           projectId: parseInt(projectId),
           userCode: code,
-          fileName: fileName,
+          folderName: folderName,
         }),
       },
       true,
@@ -80,11 +80,11 @@ export const useGenerateCSQuestions = () => {
     mutationFn: ({
       projectId,
       code,
-      fileName,
+      folderName,
     }: {
       projectId: string
       code: string
-      fileName: string
-    }) => generateCSQuestions(projectId, code, fileName),
+      folderName: string
+    }) => generateCSQuestions(projectId, code, folderName),
   })
 }

--- a/src/api/services/question/types.ts
+++ b/src/api/services/question/types.ts
@@ -9,7 +9,7 @@ import {
 export interface CreateProjectCsQuestionRequest {
   projectId: number
   userCode: string
-  fileName?: string
+  folderName?: string
 }
 
 // 피드백 요청 타입 정의

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -293,3 +293,28 @@ body {
     animation: pulse 2s infinite;
   }
 }
+
+/* Custom scrollbar styles */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #a1a1a1;
+}
+
+/* Firefox scrollbar compatibility */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #c1c1c1 #f1f1f1;
+}

--- a/src/components/DetailProject/code-selection/index.tsx
+++ b/src/components/DetailProject/code-selection/index.tsx
@@ -17,7 +17,7 @@ import { FileItem } from '@/api'
 interface CodeSelectionTabProps {
   projectId: string
   files?: FileItem[]
-  onSelectCodeSnippet: (snippet: string, fileName: string) => void
+  onSelectCodeSnippet: (snippet: string, folderName: string) => void
 }
 
 export default function CodeSelectionTab({

--- a/src/components/DetailProject/code-selection/useCodeSelection.ts
+++ b/src/components/DetailProject/code-selection/useCodeSelection.ts
@@ -50,7 +50,6 @@ export default function useCodeSelection({ projectId }: UseCodeSelectionProps) {
         // 경로에 따라 GitHub API 호출
         // 참고: GitHub API는 폴더별로 별도 요청이 필요함
         const fileItems = await getProjectFiles(projectId, undefined, path)
-        console.log('현재 경로 항목:', fileItems)
 
         setFiles(fileItems)
 

--- a/src/components/DetailProject/cs-questions/index.tsx
+++ b/src/components/DetailProject/cs-questions/index.tsx
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button'
 const CSQuestionsTab: React.FC<CSQuestionsTabProps> = ({
   projectId,
   codeSnippet = '',
-  fileName = '',
+  folderName = '',
   onAnswerSubmit,
   onSaveQuestion,
   onTabChange,
@@ -51,7 +51,7 @@ const CSQuestionsTab: React.FC<CSQuestionsTabProps> = ({
     handleSubmitAnswer,
     handleSaveQuestion,
     toggleLearningInsights,
-  } = useCSQuestions({ projectId, codeSnippet, fileName })
+  } = useCSQuestions({ projectId, codeSnippet, folderName })
 
   const handleSubmit = useCallback(async () => {
     await handleSubmitAnswer(onAnswerSubmit)

--- a/src/components/DetailProject/cs-questions/index.tsx
+++ b/src/components/DetailProject/cs-questions/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useState, useEffect } from 'react'
+import React, { useCallback, useState, useEffect, useRef, useMemo } from 'react'
 import { Loader2 } from 'lucide-react'
 import { CSQuestionsTabProps } from '../types'
 import QuestionList from './QuestionList'
@@ -24,8 +24,11 @@ const CSQuestionsTab: React.FC<CSQuestionsTabProps> = ({
   onAnswerSubmit,
   onSaveQuestion,
   onTabChange,
+  onQuestionsLoad,
 }) => {
   const [activeTab, setActiveTab] = useState('questions')
+  // 이전 질문 목록의 ID를 저장할 ref
+  const prevQuestionsIdsRef = useRef<string>('')
 
   const {
     // 상태
@@ -52,6 +55,22 @@ const CSQuestionsTab: React.FC<CSQuestionsTabProps> = ({
     handleSaveQuestion,
     toggleLearningInsights,
   } = useCSQuestions({ projectId, codeSnippet, folderName })
+
+  // 질문 ID 문자열을 계산하고 메모이제이션
+  const questionIds = useMemo(() => {
+    return questions.map((q) => q.id).join(',')
+  }, [questions])
+
+  // 질문 목록이 로드됐을 때 부모 컴포넌트에 알림
+  useEffect(() => {
+    if (questions.length > 0 && onQuestionsLoad) {
+      // 이전 질문 ID와 현재 질문 ID가 다른 경우에만 호출
+      if (questionIds !== prevQuestionsIdsRef.current) {
+        onQuestionsLoad(questions)
+        prevQuestionsIdsRef.current = questionIds
+      }
+    }
+  }, [questions, onQuestionsLoad, questionIds])
 
   const handleSubmit = useCallback(async () => {
     await handleSubmitAnswer(onAnswerSubmit)

--- a/src/components/DetailProject/cs-questions/useCSQuestions.ts
+++ b/src/components/DetailProject/cs-questions/useCSQuestions.ts
@@ -9,13 +9,13 @@ import { CSQuestion } from '@/api'
 interface UseCSQuestionsProps {
   projectId: string
   codeSnippet?: string
-  fileName?: string
+  folderName?: string
 }
 
 export default function useCSQuestions({
   projectId,
   codeSnippet = '',
-  fileName = '',
+  folderName = '',
 }: UseCSQuestionsProps) {
   // QueryClient 인스턴스 가져오기
   const queryClient = useQueryClient()
@@ -56,8 +56,8 @@ export default function useCSQuestions({
     isLoading,
     error,
   } = useQuery<CSQuestion[]>({
-    queryKey: ['csQuestions', projectId, codeSnippet, fileName],
-    queryFn: () => generateCSQuestions(projectId, codeSnippet, fileName),
+    queryKey: ['csQuestions', projectId, codeSnippet, folderName],
+    queryFn: () => generateCSQuestions(projectId, codeSnippet, folderName),
     enabled: !!projectId && !!codeSnippet,
     staleTime: 1000 * 60 * 30, // 30분간 데이터 유지
     gcTime: 1000 * 60 * 60, // 60분간 캐시 유지
@@ -103,7 +103,7 @@ export default function useCSQuestions({
         userAnswer: '',
         feedback: '',
         codeSnippet: codeSnippet.substring(0, 100) + '...',
-        fileName, // 파일명 추가
+        folderName: folderName, // folderName 저장
       }))
 
       setQuestions(initialQuestions)
@@ -135,7 +135,13 @@ export default function useCSQuestions({
         setSelectedQuestionId(initialQuestions[0].id)
       }
     }
-  }, [csQuestions, codeSnippet, fileName, selectedQuestionId, questions.length])
+  }, [
+    csQuestions,
+    codeSnippet,
+    folderName,
+    selectedQuestionId,
+    questions.length,
+  ])
 
   // 모든 질문이 답변되었는지 확인
   useEffect(() => {

--- a/src/components/DetailProject/cs-questions/useCSQuestions.ts
+++ b/src/components/DetailProject/cs-questions/useCSQuestions.ts
@@ -214,10 +214,6 @@ export default function useCSQuestions({
         )
 
         setFeedback(result)
-        // 완료된 질문을 저장된 질문 목록에 추가
-        if (!savedQuestions.includes(selectedQuestionId)) {
-          setSavedQuestions((prev) => [...prev, selectedQuestionId])
-        }
       } catch (error) {
         console.error('답변 제출 중 오류 발생:', error)
         setFeedback('답변 제출 중 오류가 발생했습니다.')
@@ -225,7 +221,7 @@ export default function useCSQuestions({
         setLoading(false)
       }
     },
-    [selectedQuestionId, answer, savedQuestions],
+    [selectedQuestionId, answer],
   )
 
   const handleSaveQuestion = useCallback(

--- a/src/components/DetailProject/index.tsx
+++ b/src/components/DetailProject/index.tsx
@@ -38,7 +38,7 @@ export const DetailProject = ({ params }: DetailProjectProps) => {
   const [error, setError] = useState<string | null>(null)
   const [questionHistory, setQuestionHistory] = useState<any | null>(null)
   const [selectedCodeSnippet, setSelectedCodeSnippet] = useState<string>('')
-  const [selectedFileName, setSelectedFileName] = useState<string>('')
+  const [selectedFolderName, setSelectedFolderName] = useState<string>('')
 
   // 수정 및 삭제 관련 상태
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
@@ -90,9 +90,9 @@ export const DetailProject = ({ params }: DetailProjectProps) => {
 
   // CS 질문 생성 핸들러
   const handleGenerateQuestions = useCallback(
-    (code: string, fileName: string) => {
+    (code: string, folderName: string) => {
       setSelectedCodeSnippet(code)
-      setSelectedFileName(fileName)
+      setSelectedFolderName(folderName)
       // 질문 생성 후 CS 질문 탭으로 전환
       setSelectedTab('cs-questions')
     },
@@ -259,7 +259,7 @@ export const DetailProject = ({ params }: DetailProjectProps) => {
           <CSQuestionsTab
             projectId={projectId}
             codeSnippet={selectedCodeSnippet}
-            fileName={selectedFileName}
+            folderName={selectedFolderName}
             onAnswerSubmit={handleAnswerSubmit}
             onSaveQuestion={handleSaveQuestion}
             onChooseAnotherCode={handleChooseAnotherCode}

--- a/src/components/DetailProject/index.tsx
+++ b/src/components/DetailProject/index.tsx
@@ -275,7 +275,8 @@ export const DetailProject = ({ params }: DetailProjectProps) => {
             initialHistory={questionHistory}
             onBookmarkQuestion={handleBookmarkQuestion}
             onAnswerSubmit={handleAnswerSubmit}
-            onTabChange={(tabId) => setSelectedTab(tabId)}
+            onTabChange={setSelectedTab}
+            activeTab={selectedTab}
           />
         </TabsContent>
       </Tabs>

--- a/src/components/DetailProject/index.tsx
+++ b/src/components/DetailProject/index.tsx
@@ -274,6 +274,8 @@ export const DetailProject = ({ params }: DetailProjectProps) => {
             projectId={projectId}
             initialHistory={questionHistory}
             onBookmarkQuestion={handleBookmarkQuestion}
+            onAnswerSubmit={handleAnswerSubmit}
+            onTabChange={(tabId) => setSelectedTab(tabId)}
           />
         </TabsContent>
       </Tabs>

--- a/src/components/DetailProject/question-history/HistoryList.tsx
+++ b/src/components/DetailProject/question-history/HistoryList.tsx
@@ -11,6 +11,7 @@ interface HistoryListProps {
   selectedQuestionId?: number
   bookmarkedQuestions: number[]
   onSelectQuestion: (question: QuestionHistoryItem) => void
+  onAnswer?: (question: QuestionHistoryItem) => void
 }
 
 /**
@@ -22,6 +23,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
   selectedQuestionId,
   bookmarkedQuestions,
   onSelectQuestion,
+  onAnswer,
 }) => {
   // 각 날짜별 열림/닫힘 상태 관리
   const [expandedDates, setExpandedDates] = useState<Record<string, boolean>>(
@@ -97,18 +99,25 @@ const HistoryList: React.FC<HistoryListProps> = ({
                       const statusText = isDone ? '답변됨' : '답변필요'
                       const statusColor = isDone ? 'green' : 'yellow'
 
+                      // QuestionItem 생성
+                      const questionItem = {
+                        id: questionId,
+                        answered: isAnswered,
+                        question: question.question || '질문 내용 없음',
+                        codeSnippet: question.codeSnippet || '',
+                        fileName: (question as any).fileName || '',
+                        status: isDone ? 'DONE' : 'TODO',
+                        userAnswer: question.answer || '',
+                        feedback: question.feedback || '',
+                      }
+
                       return (
                         <QuestionCard
                           key={questionId || `question-${date}-${index}`}
-                          question={{
-                            ...question,
-                            id: questionId,
-                            answered: isAnswered,
-                            question: question.question || '질문 내용 없음',
-                            codeSnippet: question.codeSnippet || '',
-                            fileName: (question as any).fileName || '',
-                          }}
-                          isSelected={selectedQuestionId === questionId}
+                          question={questionItem}
+                          isSelected={
+                            Number(selectedQuestionId) === Number(questionId)
+                          }
                           isBookmarked={bookmarkedQuestions.includes(
                             questionId,
                           )}
@@ -121,6 +130,18 @@ const HistoryList: React.FC<HistoryListProps> = ({
                           }
                           statusText={statusText}
                           statusColor={statusColor}
+                          onAnswer={
+                            onAnswer
+                              ? () =>
+                                  onAnswer({
+                                    ...question,
+                                    id: questionId,
+                                    question:
+                                      question.question || '질문 내용 없음',
+                                    fileName: (question as any).fileName || '',
+                                  })
+                              : undefined
+                          }
                         />
                       )
                     })}

--- a/src/components/DetailProject/question-history/HistoryList.tsx
+++ b/src/components/DetailProject/question-history/HistoryList.tsx
@@ -72,9 +72,9 @@ const HistoryList: React.FC<HistoryListProps> = ({
             </div>
 
             {expandedDates[date] && (
-              <div className="p-3">
+              <div className="px-3 pt-2 pb-3">
                 {questionsCount > 0 ? (
-                  <div className="space-y-2">
+                  <div className="custom-scrollbar max-h-[400px] space-y-2 overflow-y-auto pr-2">
                     {questions.map((question, index) => {
                       // ID 값 확인하고 보정
                       const questionId =

--- a/src/components/DetailProject/question-history/HistoryList.tsx
+++ b/src/components/DetailProject/question-history/HistoryList.tsx
@@ -105,7 +105,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
                         answered: isAnswered,
                         question: question.question || '질문 내용 없음',
                         codeSnippet: question.codeSnippet || '',
-                        fileName: (question as any).fileName || '',
+                        folderName: (question as any).folderName || '',
                         status: isDone ? 'DONE' : 'TODO',
                         userAnswer: question.answer || '',
                         feedback: question.feedback || '',
@@ -125,7 +125,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
                             onSelectQuestion({
                               ...question,
                               id: questionId,
-                              fileName: (question as any).fileName,
+                              folderName: (question as any).folderName,
                             })
                           }
                           statusText={statusText}
@@ -139,6 +139,8 @@ const HistoryList: React.FC<HistoryListProps> = ({
                                     question:
                                       question.question || '질문 내용 없음',
                                     fileName: (question as any).fileName || '',
+                                    folderName:
+                                      (question as any).folderName || '',
                                   })
                               : undefined
                           }

--- a/src/components/DetailProject/question-history/QuestionDetail.tsx
+++ b/src/components/DetailProject/question-history/QuestionDetail.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { QuestionHistoryItem } from '../types'
-import { FileCode, MessageSquareText, CheckCircle, Loader2 } from 'lucide-react'
+import { FileCode, MessageSquareText, Loader2, AlertCircle } from 'lucide-react'
 
 interface QuestionDetailProps {
   question: QuestionHistoryItem | null
@@ -14,6 +14,7 @@ interface QuestionDetailProps {
     question: QuestionHistoryItem,
     answer: string,
   ) => Promise<string | undefined>
+  activeCSQuestionIds?: number[] // CS 질문 탭에서 활성화된 질문 ID 목록
 }
 
 /**
@@ -24,11 +25,16 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
   isBookmarked,
   onBookmark,
   onAnswer,
+  activeCSQuestionIds = [], // 기본값은 빈 배열
 }) => {
   const [userAnswer, setUserAnswer] = useState('')
   const [feedback, setFeedback] = useState<string | null>(null)
   const [isAnswering, setIsAnswering] = useState(false)
   const [isAnswered, setIsAnswered] = useState(false)
+
+  // 현재 질문이 CS 질문 탭에서 답변 중인지 확인
+  const isActiveCSQuestion =
+    question && activeCSQuestionIds.includes(question.id)
 
   // 질문이 변경될 때마다 상태 초기화 및 이미 답변된 질문인지 확인
   useEffect(() => {
@@ -108,7 +114,17 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
       </div>
 
       <div className="mt-6 space-y-4">
-        {isTodo && onAnswer ? (
+        {isActiveCSQuestion && (
+          <div className="mb-4 flex items-center gap-2 rounded-md bg-amber-50 p-3 text-amber-700">
+            <AlertCircle className="h-4 w-4" />
+            <p className="text-sm">
+              이 질문은 현재 CS 질문 탭에서 답변 중인 질문입니다. CS 질문 탭에서
+              답변해주세요.
+            </p>
+          </div>
+        )}
+
+        {isTodo && onAnswer && !isActiveCSQuestion ? (
           <div className="space-y-2">
             <h4 className="flex items-center text-sm font-medium">
               내 답변{' '}

--- a/src/components/DetailProject/question-history/QuestionDetail.tsx
+++ b/src/components/DetailProject/question-history/QuestionDetail.tsx
@@ -1,14 +1,19 @@
 'use client'
 
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
 import { QuestionHistoryItem } from '../types'
-import { FileCode } from 'lucide-react'
+import { FileCode, MessageSquareText, CheckCircle, Loader2 } from 'lucide-react'
 
 interface QuestionDetailProps {
   question: QuestionHistoryItem | null
   isBookmarked: boolean
   onBookmark: (questionId: number) => void
+  onAnswer?: (
+    question: QuestionHistoryItem,
+    answer: string,
+  ) => Promise<string | undefined>
 }
 
 /**
@@ -18,13 +23,55 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
   question,
   isBookmarked,
   onBookmark,
+  onAnswer,
 }) => {
+  const [userAnswer, setUserAnswer] = useState('')
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [isAnswering, setIsAnswering] = useState(false)
+  const [isAnswered, setIsAnswered] = useState(false)
+
+  // 질문이 변경될 때마다 상태 초기화 및 이미 답변된 질문인지 확인
+  useEffect(() => {
+    if (question) {
+      setUserAnswer('') // 사용자 답변 초기화
+      setFeedback(null) // 피드백 초기화
+      setIsAnswering(false) // 답변 중 상태 초기화
+
+      // 이미 답변된 질문인지 확인
+      const hasAnswer = !!question.answer && question.answer.trim() !== ''
+      const isDone = question.status === 'DONE' || question.answered === true
+      setIsAnswered(hasAnswer || isDone)
+    }
+  }, [question?.id, question?.answer, question?.status, question?.answered])
+
   if (!question) {
     return (
       <div className="flex h-60 items-center justify-center text-slate-500">
         왼쪽에서 질문을 선택해주세요.
       </div>
     )
+  }
+
+  // 안전하게 status 확인 (undefined 또는 다른 타입일 수 있음)
+  const isTodo =
+    (!question.answer || question.answer === '') &&
+    question.status !== 'DONE' &&
+    question.answered !== true
+
+  const handleAnswerSubmit = async () => {
+    if (!onAnswer || !userAnswer.trim() || !question) return
+
+    setIsAnswering(true)
+    try {
+      const result = await onAnswer(question, userAnswer)
+      setFeedback(result || '답변이 제출되었습니다.')
+      setIsAnswered(true) // 답변 제출 성공 시 상태 업데이트
+    } catch (error) {
+      console.error('답변 제출 중 오류 발생:', error)
+      setFeedback('답변 제출 중 오류가 발생했습니다.')
+    } finally {
+      setIsAnswering(false)
+    }
   }
 
   return (
@@ -47,7 +94,7 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
           </div>
         )}
 
-        <div className="mt-3 flex justify-end">
+        <div className="mt-3 flex justify-end space-x-2">
           <Button
             variant="outline"
             size="sm"
@@ -61,19 +108,64 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
       </div>
 
       <div className="mt-6 space-y-4">
-        <div className="rounded-md bg-slate-50 p-3">
-          <h4 className="mb-2 text-sm font-medium">내 답변</h4>
-          <div className="text-sm whitespace-pre-line text-slate-700">
-            {question.answer || '답변이 없습니다.'}
+        {isTodo && onAnswer ? (
+          <div className="space-y-2">
+            <h4 className="flex items-center text-sm font-medium">
+              내 답변{' '}
+              <MessageSquareText className="ml-1 h-4 w-4 text-blue-500" />
+            </h4>
+            <Textarea
+              value={userAnswer}
+              onChange={(e) => setUserAnswer(e.target.value)}
+              placeholder="답변을 작성해 주세요..."
+              className="min-h-[150px] resize-none"
+              disabled={isAnswering || isAnswered}
+            />
+            <div className="flex justify-end">
+              <Button
+                onClick={handleAnswerSubmit}
+                disabled={isAnswering || !userAnswer.trim() || isAnswered}
+                className="flex items-center gap-2"
+              >
+                {isAnswering ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>제출 중...</span>
+                  </>
+                ) : (
+                  '답변 제출'
+                )}
+              </Button>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="rounded-md bg-slate-50 p-3">
+            <h4 className="mb-2 text-sm font-medium">내 답변</h4>
+            <div className="text-sm whitespace-pre-line text-slate-700">
+              {question.answer || '답변이 없습니다.'}
+            </div>
+          </div>
+        )}
 
-        <div className="rounded-md bg-green-50 p-3">
-          <h4 className="mb-2 text-sm font-medium text-green-700">피드백</h4>
-          <div className="text-sm whitespace-pre-line text-green-600">
-            {question.feedback || '피드백이 없습니다.'}
+        {feedback ? (
+          <div className="rounded-md bg-green-50 p-3">
+            <h4 className="mb-2 text-sm font-medium text-green-700">피드백</h4>
+            <div className="text-sm whitespace-pre-line text-green-600">
+              {feedback}
+            </div>
           </div>
-        </div>
+        ) : (
+          question.feedback && (
+            <div className="rounded-md bg-green-50 p-3">
+              <h4 className="mb-2 text-sm font-medium text-green-700">
+                피드백
+              </h4>
+              <div className="text-sm whitespace-pre-line text-green-600">
+                {question.feedback}
+              </div>
+            </div>
+          )
+        )}
       </div>
     </div>
   )

--- a/src/components/DetailProject/question-history/index.tsx
+++ b/src/components/DetailProject/question-history/index.tsx
@@ -19,6 +19,7 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
   onAnswerSubmit,
   onTabChange,
   activeTab,
+  activeCSQuestionIds = [], // CS 질문 탭에서 활성화된 질문 ID 목록
 }) => {
   // 이전에 활성화된 탭을 추적하는 ref
   const prevActiveTabRef = useRef<string | undefined>(undefined)
@@ -63,7 +64,14 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
     try {
       if (!answer.trim()) return undefined
 
-      const questionId = question.id || question.questionId || 0
+      // ID 안전하게 추출 (간소화된 방식)
+      const questionId =
+        question.id ?? question.questionId ?? question.csQuestionId ?? 0
+
+      if (!questionId) {
+        console.error('유효하지 않은 질문 ID:', question)
+        return '유효하지 않은 질문입니다.'
+      }
 
       let feedback: string
       if (onAnswerSubmit) {
@@ -73,7 +81,7 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
         feedback = await submitCSAnswer(questionId, answer)
       }
 
-      // 최적화된 방식으로 해당 질문만 업데이트
+      // 질문 상태 업데이트
       updateQuestion(questionId, {
         answer,
         feedback,
@@ -91,8 +99,12 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
   // CS 질문 탭으로 이동
   const handleAnswerInQuestionTab = (question: any) => {
     if (onTabChange) {
+      // ID 안전하게 추출 (간소화된 방식)
+      const questionId =
+        question.id ?? question.questionId ?? question.csQuestionId ?? 0
+
       // 질문 ID를 세션 스토리지에 저장
-      sessionStorage.setItem('selectedQuestionId', String(question.id))
+      sessionStorage.setItem('selectedQuestionId', String(questionId))
       onTabChange('cs-questions')
     }
   }
@@ -156,6 +168,7 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
               }
               onBookmark={(id) => handleBookmark(id, onBookmarkQuestion)}
               onAnswer={handleAnswerSubmit}
+              activeCSQuestionIds={activeCSQuestionIds}
             />
           )}
         </div>

--- a/src/components/DetailProject/question-history/index.tsx
+++ b/src/components/DetailProject/question-history/index.tsx
@@ -48,7 +48,6 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
       activeTab === 'question-history' &&
       prevActiveTabRef.current !== 'question-history'
     ) {
-      console.log('질문 이력 탭으로 전환됨, 데이터 새로고침')
       didSwitchToThisTabRef.current = true
       refreshHistory().then(() => {
         didSwitchToThisTabRef.current = false
@@ -95,8 +94,6 @@ const QuestionHistoryTab: React.FC<QuestionHistoryTabProps> = ({
       // 질문 ID를 세션 스토리지에 저장
       sessionStorage.setItem('selectedQuestionId', String(question.id))
       onTabChange('cs-questions')
-    } else {
-      console.log('탭 변경 기능을 사용할 수 없습니다.')
     }
   }
 

--- a/src/components/DetailProject/question-history/useQuestionHistory.ts
+++ b/src/components/DetailProject/question-history/useQuestionHistory.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { getCSQuestionHistory, getQuestionDetail } from '@/api'
 import { HistoryByDate, QuestionHistoryItem } from '../types'
 
@@ -9,18 +9,97 @@ interface UseQuestionHistoryProps {
   initialHistory?: HistoryByDate
 }
 
+// 정규화된 데이터 구조를 위한 인터페이스
+interface NormalizedQuestions {
+  byId: Record<number, QuestionHistoryItem>
+  byDate: Record<string, number[]>
+  allDates: string[]
+}
+
 export default function useQuestionHistory({
   projectId,
   initialHistory,
 }: UseQuestionHistoryProps) {
-  const [history, setHistory] = useState<HistoryByDate>(initialHistory || {})
+  // 정규화된 데이터 구조로 상태 관리
+  const [questionsData, setQuestionsData] = useState<NormalizedQuestions>(
+    () => {
+      if (!initialHistory) {
+        return { byId: {}, byDate: {}, allDates: [] }
+      }
+
+      // 초기 데이터 정규화
+      const byId: Record<number, QuestionHistoryItem> = {}
+      const byDate: Record<string, number[]> = {}
+      const allDates = Object.keys(initialHistory).sort(
+        (a, b) => new Date(b).getTime() - new Date(a).getTime(),
+      )
+
+      allDates.forEach((date) => {
+        const questions = initialHistory[date] || []
+        byDate[date] = []
+
+        questions.forEach((question) => {
+          const id = (question as any).questionId || question.id || 0
+          if (id) {
+            byId[id] = question
+            byDate[date].push(id)
+          }
+        })
+      })
+
+      return { byId, byDate, allDates }
+    },
+  )
+
   const [loading, setLoading] = useState(!initialHistory)
-  const [selectedQuestion, setSelectedQuestion] =
-    useState<QuestionHistoryItem | null>(null)
+  const [selectedQuestionId, setSelectedQuestionId] = useState<number | null>(
+    null,
+  )
   const [detailLoading, setDetailLoading] = useState(false)
   const [bookmarkedQuestions, setBookmarkedQuestions] = useState<number[]>([])
+
+  // 메모이제이션된 현재 선택된 질문
+  const selectedQuestion = useMemo(
+    () =>
+      selectedQuestionId !== null
+        ? questionsData.byId[selectedQuestionId]
+        : null,
+    [selectedQuestionId, questionsData.byId],
+  )
+
+  // 메모이제이션된 현재 질문 (상세 정보 포함)
   const [currentQuestion, setCurrentQuestion] =
     useState<QuestionHistoryItem | null>(null)
+
+  // 메모이제이션된 날짜 정렬 (최신순)
+  const sortedDates = useMemo(
+    () => questionsData.allDates,
+    [questionsData.allDates],
+  )
+
+  // 메모이제이션된 이력 데이터
+  const history = useMemo(() => {
+    const result: HistoryByDate = {}
+
+    sortedDates.forEach((date) => {
+      const questionIds = questionsData.byDate[date] || []
+      result[date] = questionIds
+        .map((id) => {
+          const question = questionsData.byId[id]
+          if (!question) return null
+          // 모든 필수 필드 보장
+          return {
+            ...question,
+            answer: question.answer || '',
+            feedback: question.feedback || '',
+            codeSnippet: question.codeSnippet || '',
+          }
+        })
+        .filter(Boolean) as QuestionHistoryItem[]
+    })
+
+    return result
+  }, [questionsData, sortedDates])
 
   // 질문 이력 가져오기
   useEffect(() => {
@@ -30,7 +109,28 @@ export default function useQuestionHistory({
       setLoading(true)
       try {
         const data = await getCSQuestionHistory(projectId)
-        setHistory(data)
+
+        // 받아온 데이터 정규화
+        const byId: Record<number, QuestionHistoryItem> = {}
+        const byDate: Record<string, number[]> = {}
+        const allDates = Object.keys(data).sort(
+          (a, b) => new Date(b).getTime() - new Date(a).getTime(),
+        )
+
+        allDates.forEach((date) => {
+          const questions = data[date] || []
+          byDate[date] = []
+
+          questions.forEach((question) => {
+            const id = (question as any).questionId || question.id || 0
+            if (id) {
+              byId[id] = question
+              byDate[date].push(id)
+            }
+          })
+        })
+
+        setQuestionsData({ byId, byDate, allDates })
       } catch (error) {
         console.error('질문 이력을 가져오는 중 오류 발생:', error)
       } finally {
@@ -42,46 +142,77 @@ export default function useQuestionHistory({
   }, [projectId, initialHistory])
 
   // 질문 선택 핸들러 - 상세 정보 API 호출 추가
-  const handleSelectQuestion = async (
-    selectedQuestion: QuestionHistoryItem | null,
-  ) => {
-    if (!selectedQuestion) {
-      setCurrentQuestion(null)
-      setSelectedQuestion(null)
-      return
-    }
+  const handleSelectQuestion = useCallback(
+    async (question: QuestionHistoryItem | null) => {
+      if (!question) {
+        setCurrentQuestion(null)
+        setSelectedQuestionId(null)
+        return
+      }
 
-    setSelectedQuestion(selectedQuestion)
-    setDetailLoading(true)
+      const questionId = (question as any).questionId || question.id || 0
+      setSelectedQuestionId(questionId)
+      setDetailLoading(true)
 
-    try {
-      // 기본 정보는 바로 설정 (API 실패해도 최소한의 정보는 표시)
-      setCurrentQuestion({
-        ...selectedQuestion,
-        question: selectedQuestion.question || '',
-        answer: selectedQuestion.answer || '',
-        codeSnippet: selectedQuestion.codeSnippet || '',
-        feedback: selectedQuestion.feedback || '',
+      try {
+        // 기본 정보는 바로 설정 (API 실패해도 최소한의 정보는 표시)
+        setCurrentQuestion({
+          ...question,
+          question: question.question || '',
+          answer: question.answer || '',
+          codeSnippet: question.codeSnippet || '',
+          feedback: question.feedback || '',
+        })
+
+        // 상세 정보 API 호출
+        const response = await getQuestionDetail(questionId)
+
+        if (response) {
+          setCurrentQuestion({
+            ...response,
+            id: questionId, // 기존 id 유지
+          })
+        }
+      } catch (error) {
+        console.error('질문 상세 정보를 불러오는 중 오류 발생:', error)
+        // 오류 발생해도 기본 정보는 유지
+      } finally {
+        setDetailLoading(false)
+      }
+    },
+    [],
+  )
+
+  // 개별 질문 업데이트 - 최적화된 업데이트 로직
+  const updateQuestion = useCallback(
+    (questionId: number, updates: Partial<QuestionHistoryItem>) => {
+      setQuestionsData((prevData) => {
+        // 해당 질문이 존재하지 않으면 변경 없음
+        if (!prevData.byId[questionId]) return prevData
+
+        // 변경된 질문 데이터
+        const updatedQuestion = {
+          ...prevData.byId[questionId],
+          ...updates,
+        }
+
+        // 최적화된 업데이트: 변경된 질문만 업데이트
+        return {
+          ...prevData,
+          byId: {
+            ...prevData.byId,
+            [questionId]: updatedQuestion,
+          },
+        }
       })
 
-      // 상세 정보 API 호출 - questionId 사용
-      const actualId =
-        (selectedQuestion as any).questionId || selectedQuestion.id
-      const response = await getQuestionDetail(actualId)
-
-      if (response) {
-        setCurrentQuestion({
-          ...response,
-          id: selectedQuestion.id, // 기존 id 유지
-        })
+      // 현재 선택된 질문이 업데이트 대상이면 현재 질문도 업데이트
+      if (selectedQuestionId === questionId) {
+        setCurrentQuestion((prev) => (prev ? { ...prev, ...updates } : null))
       }
-    } catch (error) {
-      console.error('질문 상세 정보를 불러오는 중 오류 발생:', error)
-      // 오류 발생해도 기본 정보는 유지
-    } finally {
-      setDetailLoading(false)
-    }
-  }
+    },
+    [selectedQuestionId],
+  )
 
   // 북마크 핸들러
   const handleBookmark = useCallback(
@@ -106,11 +237,6 @@ export default function useQuestionHistory({
     [],
   )
 
-  // 날짜 정렬 (최신순)
-  const sortedDates = Object.keys(history).sort((a, b) => {
-    return new Date(b).getTime() - new Date(a).getTime()
-  })
-
   return {
     history,
     loading,
@@ -121,5 +247,6 @@ export default function useQuestionHistory({
     sortedDates,
     handleSelectQuestion,
     handleBookmark,
+    updateQuestion, // 최적화된 업데이트 함수 추가
   }
 }

--- a/src/components/DetailProject/types.ts
+++ b/src/components/DetailProject/types.ts
@@ -2,7 +2,6 @@ import {
   Project,
   CSQuestion,
   HistoryByDate as ImportedHistoryByDate,
-  QuestionHistoryItem as ImportedQuestionHistoryItem,
 } from '@/api/mocks/handlers/project'
 import { RefObject } from 'react'
 
@@ -30,16 +29,21 @@ export interface CodeSelectionTabProps {
   onSelectCodeSnippet: (snippet: string, fileName: string) => void
 }
 
-// CS 질문 관련 타입
-export interface QuestionItem {
+// CS 질문 관련 타입 (공통 속성)
+interface BaseQuestion {
   id: number
   question: string
+  codeSnippet?: string
+  fileName?: string
+  status?: string
+}
+
+// CS 질문 관련 타입
+export interface QuestionItem extends BaseQuestion {
   bestAnswer?: string
   answered?: boolean
   userAnswer?: string
   feedback?: string
-  codeSnippet?: string
-  fileName?: string
 }
 
 // CS 질문 탭 props
@@ -60,6 +64,8 @@ export interface QuestionHistoryTabProps {
   projectId: string
   initialHistory?: HistoryByDate
   onBookmarkQuestion?: (questionId: number) => Promise<boolean>
+  onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
+  onTabChange?: (tabId: string) => void
 }
 
 // 재사용 가능한 UI 컴포넌트 props
@@ -78,17 +84,21 @@ export interface QuestionCardProps {
   statusText?: string
   statusColor?: 'green' | 'yellow' | 'red' | 'blue'
   onClick?: () => void
+  onAnswer?: (question: QuestionItem) => void
 }
 
-// 질문 이력 아이템 타입 (확장)
-export interface QuestionHistoryItem extends ImportedQuestionHistoryItem {
+// 질문 이력 아이템 타입
+export interface QuestionHistoryItem extends BaseQuestion {
   // API 응답에서 가능한 필드
-  fileName?: string
+  csQuestionId?: number
+  answer?: string
+  feedback?: string
+  answered?: boolean
   concept?: string
   date?: string
-  questionId?: number
-  csQuestionId?: number
   userCode?: string
+  // API와 프론트엔드에서 사용하는 공통 필드
+  questionId?: number // API 응답에서 대체 ID로 사용될 수 있음
 }
 
 // 날짜별 질문 이력 타입

--- a/src/components/DetailProject/types.ts
+++ b/src/components/DetailProject/types.ts
@@ -26,7 +26,7 @@ export interface ProjectHeaderProps {
 export interface CodeSelectionTabProps {
   projectId: string
   files?: string[]
-  onSelectCodeSnippet: (snippet: string, fileName: string) => void
+  onSelectCodeSnippet: (snippet: string, folderName: string) => void
 }
 
 // CS 질문 관련 타입 (공통 속성)
@@ -35,6 +35,7 @@ interface BaseQuestion {
   question: string
   codeSnippet?: string
   fileName?: string
+  folderName?: string
   status?: string
 }
 
@@ -50,7 +51,7 @@ export interface QuestionItem extends BaseQuestion {
 export interface CSQuestionsTabProps {
   projectId: string
   codeSnippet?: string
-  fileName?: string
+  folderName?: string
   onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
   onSaveQuestion?: (questionId: number) => Promise<boolean | undefined>
   onChooseAnotherCode?: () => void

--- a/src/components/DetailProject/types.ts
+++ b/src/components/DetailProject/types.ts
@@ -3,7 +3,6 @@ import {
   CSQuestion,
   HistoryByDate as ImportedHistoryByDate,
 } from '@/api/mocks/handlers/project'
-import { RefObject } from 'react'
 
 // 프로젝트 데이터 타입
 export interface ProjectData extends Project {}
@@ -68,6 +67,7 @@ export interface QuestionHistoryTabProps {
   onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
   onTabChange?: (tabId: string) => void
   activeTab?: string
+  activeCSQuestionIds?: number[]
 }
 
 // 재사용 가능한 UI 컴포넌트 props
@@ -89,19 +89,38 @@ export interface QuestionCardProps {
   onAnswer?: (question: QuestionItem) => void
 }
 
-// 질문 이력 아이템 타입
+// 질문 이력 아이템 기본 타입
 export interface QuestionHistoryItem extends BaseQuestion {
-  // API 응답에서 가능한 필드
-  csQuestionId?: number
   answer?: string
   feedback?: string
   answered?: boolean
-  concept?: string
-  date?: string
-  userCode?: string
-  // API와 프론트엔드에서 사용하는 공통 필드
-  questionId?: number // API 응답에서 대체 ID로 사용될 수 있음
+  createdAt?: string
+  questionId?: number
+  csQuestionId?: number
+
+  [key: string]: any
 }
 
 // 날짜별 질문 이력 타입
 export interface HistoryByDate extends ImportedHistoryByDate {}
+
+// 탭 컴포넌트 공통 속성
+export interface TabProps {
+  projectId: string
+  onTabChange?: (tabId: string) => void
+}
+
+// CS 질문 탭 컴포넌트 속성
+export interface CSQuestionsTabProps extends TabProps {
+  codeSnippet?: string
+  folderName?: string
+  onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
+  onSaveQuestion?: (questionId: number) => Promise<boolean | undefined>
+  onQuestionsLoad?: (questions: any[]) => void
+}
+
+// 코드 선택 탭 컴포넌트 속성
+export interface CodeSelectionTabProps extends TabProps {
+  onSelectedCode?: (code: string) => void
+  onFinish?: () => void
+}

--- a/src/components/DetailProject/types.ts
+++ b/src/components/DetailProject/types.ts
@@ -67,6 +67,7 @@ export interface QuestionHistoryTabProps {
   onBookmarkQuestion?: (questionId: number) => Promise<boolean>
   onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
   onTabChange?: (tabId: string) => void
+  activeTab?: string
 }
 
 // 재사용 가능한 UI 컴포넌트 props

--- a/src/components/DetailProject/ui/QuestionCard.tsx
+++ b/src/components/DetailProject/ui/QuestionCard.tsx
@@ -46,10 +46,12 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
         )}
       </div>
 
-      {question.fileName && (
+      {(question.fileName || question.folderName) && (
         <div className="mt-2 flex items-center text-xs text-blue-600">
           <FileCode className="mr-1 h-3 w-3" />
-          <span className="truncate">{question.fileName}</span>
+          <span className="truncate">
+            {question.fileName || question.folderName}
+          </span>
         </div>
       )}
 


### PR DESCRIPTION
## 📌 관련 이슈

- 이슈 번호: #33 

## 💡 작업 내용

질문 기록 탭에서의 답변, 피드백 기능 추가
질문 카드에서 파일 이름 제대로 안보이던 버그 수정
질문 탭으로 전환시 새로고침
데이터 정규화 및 메모이제이션
CS 질문 탭과 질문 기록 탭 간의 동기화 기능 개선
## ✨ 주요 변경점

<!-- 핵심적인 변경 사항들을 나열해주세요 -->

- [x] useRef를 활용하여 이전 탭과 현재 탭을 추적하고, 질문 기록 탭으로 전환될 때만 서버에서 데이터를 새로 로드
- [x] useQuestionHistory 훅 개선
forceRefresh 옵션 추가
refreshHistory 함수로 선택적 데이터 새로고침 가능
불필요한 API 요청을 줄이기 위한 최적화 로직 포함
- [x] 정규화된 질문 상태 구조 적용
질문 데이터를 ID 기반으로 정규화하여 O(1) 시간 복잡도로 접근 가능
날짜별 ID 배열만 별도로 관리하여 메모리 효율성 확보
- [x] 선택적 리렌더링 및 즉시 UI 반영
질문 답변/피드백 후 서버 응답을 대기하지 않고 로컬 상태를 즉시 갱신
파생 데이터는 useMemo로 계산 비용 최소화
- [X] 질문 카드에서 파일 이름 제대로 안보이던 버그 수정
- [x] CS 질문 탭에서 활성화된 질문은 질문 기록 탭에서 경고 메시지 표시 및 답변 제한 기능 구현



## ✅ 셀프 체크리스트

<!-- PR을 제출하기 전에 아래 항목들을 확인해주세요 -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
