### PR TITLE
Feat/get commits by date

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,36 +1,55 @@
-//user
+/**
+ * API 인덱스 파일
+ * API 클라이언트 서비스와 관련 타입을 내보냅니다.
+ */
+
+// =============== 사용자 (User) ===============
+// 타입
 export type { User, UserResponse } from '@/api/services/user/model'
 export { stackNames } from '@/api/services/user/model'
 
-//====================
-// PROJECT
-//====================
-// Types
-export type { FileItem } from '@/api/services/project/model'
-export type {
-  ProjectCreateResponse,
-  ProjectCreateRequest,
-  ProjectListResponse,
-  ProjectDetailResponse,
-  ProjectUpdateRequest,
-  ProjectUpdateResponse,
-  ProjectDeleteResponse,
-} from '@/api/services/project/index'
-// Functions
+// =============== 프로젝트 (Project) ===============
 
+// 타입
+export type { Project, Commit, FileItem } from '@/api/services/project/model'
+
+// API 함수
 export {
   useProjectList,
   useProjectCreate,
+  useProjectDetail,
   useProjectUpdate,
   useProjectDelete,
-  useProjectDetail,
   mapToProject,
 } from '@/api/services/project/index'
 
-//====================
-// QUESTION
-//====================
-// Types
+// =============== GitHub 연동 ===============
+
+// 타입
+export type {
+  GithubRepo,
+  GithubRepoResponse,
+} from '@/api/services/github/githubRepo'
+
+// API 함수
+export {
+  getProjectDetail,
+  getCommitPeriods,
+  getProjectFiles,
+  getFileCode,
+  generateCSQuestions,
+} from '@/api/services/github/projectGithubService'
+
+export {
+  fetchGitHubContents,
+  fetchGitHubFile,
+} from '@/api/services/github/githubApi'
+
+export { useGithubRepos } from '@/api/services/github/githubRepo'
+
+// =============== CS 질문 (Question) ===============
+
+// 타입 - question 모듈에서 내보내기
 export type {
   CreateProjectCsQuestionRequest,
   FeedbackRequest,
@@ -43,13 +62,14 @@ export type {
   QuestionHistoryItem,
 } from '@/api/services/question/types'
 
-// Functions
+// CS 질문 생성 API
 export {
   useCreateProjectCsQuestion,
   generateCSQuestions as generateCodeCSQuestions,
   useGenerateCSQuestions,
 } from '@/api/services/question/generate'
 
+// 질문 이력 API
 export {
   getQuestionHistory as getCSQuestionHistory,
   useQuestionHistory,
@@ -57,12 +77,14 @@ export {
   bookmarkQuestion as bookmarkCSQuestion,
 } from '@/api/services/question/history'
 
+// 답변 및 피드백 API
 export {
   submitAnswer as submitCSAnswer,
   useSubmitFeedback,
   useCreateFeedback,
 } from '@/api/services/question/feedback'
 
+// 질문 조회 API
 export {
   getQuestionDetail,
   useQuestionDetail,
@@ -71,23 +93,7 @@ export {
   useProjectCsQuestionList,
 } from '@/api/services/question/query'
 
-//github
-export type {
-  GithubRepo,
-  GithubRepoResponse,
-} from '@/api/services/github/githubRepo'
-export {
-  fetchGitHubContents,
-  fetchGitHubFile,
-} from '@/api/services/github/githubApi'
-export { useGithubRepos } from '@/api/services/github/githubRepo'
-export {
-  getProjectDetail,
-  getCommitPeriods,
-  getProjectFiles,
-  getFileCode,
-  generateCSQuestions,
-} from '@/api/services/github/projectGithubService'
+// =============== 폴더 (Folder) ===============
 
 //folder
 export type {

--- a/src/api/mocks/handlers/project.ts
+++ b/src/api/mocks/handlers/project.ts
@@ -158,7 +158,7 @@ const mockQuestionHistory: HistoryByDate = {
         'React Hook은 함수형 컴포넌트에서 상태 관리와 사이드 이펙트를 처리하기 위해 도입되었습니다. 이 코드에서는 useState와 useEffect를 사용하고 있습니다.',
       feedback:
         '좋은 시도입니다! React Hook의 구체적인 사용 사례를 더 설명해보세요.',
-      fileName: 'UserProfile.jsx',
+
       answered: true,
       status: 'Done',
     },
@@ -170,7 +170,7 @@ const mockQuestionHistory: HistoryByDate = {
         'fetch API는 네트워크 요청 실패 시 HTTP 에러를 받을 수 있어 response.ok를 확인해야 합니다.',
       feedback:
         '네트워크 오류 처리에 대한 설명이 좋습니다. 개선 방안도 추가해보세요.',
-      fileName: 'UserProfile.jsx',
+
       answered: true,
       status: 'Done',
     },
@@ -182,7 +182,7 @@ const mockQuestionHistory: HistoryByDate = {
         '상태 관리 관점에서 이 컴포넌트의 특징과 성능 최적화 방법을 논의해주세요.',
       answer: '이 컴포넌트는 여러 상태를 관리하며 API 호출을 처리합니다.',
       feedback: '성능 최적화 방법에 대해 더 자세히 설명해주세요.',
-      fileName: 'App.js',
+
       answered: true,
       status: 'Done',
     },
@@ -194,7 +194,7 @@ const mockQuestionHistory: HistoryByDate = {
         'React에서 상태 관리 라이브러리를 사용하는 이유와 장단점을 설명해주세요.',
       answer: '',
       feedback: '',
-      fileName: 'App.js',
+
       answered: false,
       status: 'Todo',
     },
@@ -206,7 +206,7 @@ const mockQuestionHistory: HistoryByDate = {
         'TypeScript의 주요 기능과 JavaScript와의 차이점을 설명해주세요.',
       answer: '',
       feedback: '',
-      fileName: 'index.ts',
+
       answered: false,
       status: 'Todo',
     },

--- a/src/api/mocks/handlers/project.ts
+++ b/src/api/mocks/handlers/project.ts
@@ -131,22 +131,19 @@ const mockCSQuestions: CSQuestion[] = [
     id: 1,
     question:
       '이 코드에서 사용된 React Hook의 목적과 라이프사이클 메서드와의 관계를 설명해주세요.',
-    bestAnswer:
-      'React Hook은 함수형 컴포넌트에서 상태 관리와 사이드 이펙트를 처리하기 위해 도입되었습니다. 이 코드에서는 useState와 useEffect를 사용하고 있는데, useState는 컴포넌트의 상태를 관리하고, useEffect는 componentDidMount, componentDidUpdate, componentWillUnmount와 같은 라이프사이클 메서드의 기능을 대체합니다.',
+    relatedCode: 'useState, useEffect',
   },
   {
     id: 2,
     question:
       'fetch API를 사용할 때 발생할 수 있는 네트워크 오류 처리 방법과 이 코드의 개선점을 설명해주세요.',
-    bestAnswer:
-      'fetch API는 네트워크 요청 실패 시 reject 대신 HTTP 에러 응답을 받을 수 있으므로, response.ok를 확인하는 것이 중요합니다. 이 코드에서는 try-catch 블록으로 네트워크 오류를 처리하고 있으며, response.ok 체크도 구현되어 있습니다. 개선점으로는 타임아웃 설정, 재시도 로직, 더 구체적인 에러 메시지 제공 등이 있을 수 있습니다.',
+    relatedCode: 'fetch, try-catch',
   },
   {
     id: 3,
     question:
       '상태 관리 관점에서 이 컴포넌트의 특징과 성능 최적화 방법을 논의해주세요.',
-    bestAnswer:
-      '이 컴포넌트는 여러 상태(user, loading, error)를 관리하며, useEffect 내에서 API 호출을 처리합니다. 성능 최적화를 위해 메모이제이션(React.memo, useMemo, useCallback), 불필요한 렌더링 방지, 데이터 페칭 라이브러리(React Query) 사용, 컴포넌트 분할 등을 고려할 수 있습니다.',
+    relatedCode: 'user, loading, error 상태',
   },
 ]
 
@@ -161,7 +158,7 @@ const mockQuestionHistory: HistoryByDate = {
         'React Hook은 함수형 컴포넌트에서 상태 관리와 사이드 이펙트를 처리하기 위해 도입되었습니다. 이 코드에서는 useState와 useEffect를 사용하고 있습니다.',
       feedback:
         '좋은 시도입니다! React Hook의 구체적인 사용 사례를 더 설명해보세요.',
-      codeSnippet: 'UserProfile.jsx',
+      fileName: 'UserProfile.jsx',
       answered: true,
       status: 'Done',
     },
@@ -173,7 +170,7 @@ const mockQuestionHistory: HistoryByDate = {
         'fetch API는 네트워크 요청 실패 시 HTTP 에러를 받을 수 있어 response.ok를 확인해야 합니다.',
       feedback:
         '네트워크 오류 처리에 대한 설명이 좋습니다. 개선 방안도 추가해보세요.',
-      codeSnippet: 'UserProfile.jsx',
+      fileName: 'UserProfile.jsx',
       answered: true,
       status: 'Done',
     },
@@ -185,7 +182,7 @@ const mockQuestionHistory: HistoryByDate = {
         '상태 관리 관점에서 이 컴포넌트의 특징과 성능 최적화 방법을 논의해주세요.',
       answer: '이 컴포넌트는 여러 상태를 관리하며 API 호출을 처리합니다.',
       feedback: '성능 최적화 방법에 대해 더 자세히 설명해주세요.',
-      codeSnippet: 'App.js',
+      fileName: 'App.js',
       answered: true,
       status: 'Done',
     },
@@ -197,7 +194,7 @@ const mockQuestionHistory: HistoryByDate = {
         'React에서 상태 관리 라이브러리를 사용하는 이유와 장단점을 설명해주세요.',
       answer: '',
       feedback: '',
-      codeSnippet: 'App.js',
+      fileName: 'App.js',
       answered: false,
       status: 'Todo',
     },
@@ -209,7 +206,7 @@ const mockQuestionHistory: HistoryByDate = {
         'TypeScript의 주요 기능과 JavaScript와의 차이점을 설명해주세요.',
       answer: '',
       feedback: '',
-      codeSnippet: 'index.ts',
+      fileName: 'index.ts',
       answered: false,
       status: 'Todo',
     },

--- a/src/api/services/github/projectGithubService.ts
+++ b/src/api/services/github/projectGithubService.ts
@@ -52,7 +52,10 @@ export const getCommitPeriods = async (projectId: string) => {
 /**
  * 내부: 깃허브 저장소 정보 추출
  */
-async function getGitHubRepoInfo(projectId: string) {
+async function getGitHubRepoInfo(
+  projectId: string,
+  branch: string = 'develop',
+) {
   try {
     const response = await fetcher<any>(
       `/project/info?projectId=${projectId}`,
@@ -62,13 +65,13 @@ async function getGitHubRepoInfo(projectId: string) {
     return {
       owner: response.result?.login || 'CommitMentor',
       repo: response.result?.name || 'CoMentor-Frontend',
-      branch: 'develop',
+      branch: branch,
     }
   } catch (error) {
     return {
       owner: 'CommitMentor',
       repo: 'CoMentor-Frontend',
-      branch: 'develop',
+      branch: branch,
     }
   }
 }
@@ -80,9 +83,10 @@ export const getProjectFiles = async (
   projectId: string,
   period: string = '1week',
   path: string = '',
+  branch: string = 'develop',
 ): Promise<FileItem[]> => {
   try {
-    const { owner, repo, branch } = await getGitHubRepoInfo(projectId)
+    const { owner, repo } = await getGitHubRepoInfo(projectId, branch)
     const contents = await fetchGitHubContents(owner, repo, path, branch)
     return contents.map((item: any) => ({
       name: item.name,
@@ -102,9 +106,10 @@ export const getProjectFiles = async (
 export const getFileCode = async (
   projectId: string,
   folderName: string,
+  branch: string = 'develop',
 ): Promise<string> => {
   try {
-    const { owner, repo, branch } = await getGitHubRepoInfo(projectId)
+    const { owner, repo } = await getGitHubRepoInfo(projectId, branch)
     const content = await fetchGitHubFile(owner, repo, folderName, branch)
     return content
   } catch (error) {
@@ -182,27 +187,28 @@ export const getProjectChangedFiles = async (
   projectId: string,
   since: string,
   until: string,
+  branch: string = 'develop',
 ): Promise<FileItem[]> => {
   try {
-    const { owner, repo } = await getGitHubRepoInfo(projectId)
+    const { owner, repo } = await getGitHubRepoInfo(projectId, branch)
 
     // 변경된 파일 목록 가져오기
     const files = await getChangedFiles(owner, repo, since, until)
     if (files.length === 0) {
       console.log('변경된 파일이 없어 기본 파일 목록을 조회합니다.')
       // 변경된 파일이 없으면 모든 파일 가져오기
-      return getProjectFiles(projectId, '1year', '')
+      return getProjectFiles(projectId, '1year', '', branch)
     }
 
     // 파일 목록을 디렉토리 구조로 변환
     const rootItems = organizeFilesToDirectoryStructure(files)
     return rootItems.map((item) => ({
       ...item,
-      url: `https://github.com/${owner}/${repo}/blob/develop/${item.path}`,
+      url: `https://github.com/${owner}/${repo}/blob/${branch}/${item.path}`,
     }))
   } catch (error) {
     console.error('변경된 파일 목록 조회 중 오류:', error)
     // 오류 발생 시 기본 파일 목록 가져오기 시도
-    return getProjectFiles(projectId, '1year', '')
+    return getProjectFiles(projectId, '1year', '', branch)
   }
 }

--- a/src/api/services/github/projectGithubService.ts
+++ b/src/api/services/github/projectGithubService.ts
@@ -1,4 +1,10 @@
-import { Project, CSQuestion, FileItem } from '@/api/services/project/model'
+import {
+  Project,
+  CSQuestion,
+  FileItem,
+  CSQuestionDTO,
+  mapDtoToCSQuestion,
+} from '@/api/services/project/model'
 import { fetcher } from '@/api/lib/fetcher'
 import { fetchGitHubContents, fetchGitHubFile } from './githubApi'
 
@@ -102,7 +108,7 @@ export const getFileCode = async (
 }
 
 /**
- * CS 질문 생성
+ * CS 질문 생성 post 요청
  */
 export const generateCSQuestions = async (
   projectId: string,
@@ -113,7 +119,7 @@ export const generateCSQuestions = async (
     const response = await fetcher<{
       code: number
       message: string
-      result: any[]
+      result: CSQuestionDTO[]
     }>(
       '/question/project',
       {
@@ -123,11 +129,8 @@ export const generateCSQuestions = async (
       true,
     )
     if (response.result && Array.isArray(response.result)) {
-      return response.result.map((item) => ({
-        id: item.questionId,
-        question: item.question,
-        bestAnswer: '',
-      }))
+      // DTO에서 도메인 모델로 변환
+      return response.result.map(mapDtoToCSQuestion)
     }
     return []
   } catch (error) {

--- a/src/api/services/project/model.ts
+++ b/src/api/services/project/model.ts
@@ -49,7 +49,6 @@ export interface QuestionHistoryItem {
   id: number
   question: string
   relatedCode?: string
-  fileName?: string
   status?: string
   csQuestionId?: number
   answer?: string

--- a/src/api/services/project/model.ts
+++ b/src/api/services/project/model.ts
@@ -18,28 +18,45 @@ export interface Commit {
   commitDate: string
 }
 
-// CS 질문 타입
+// CS 질문 응답 DTO (Data Transfer Object) - 백엔드 API 응답 타입
+export interface CSQuestionDTO {
+  questionId: number
+  question: string
+  relatedCode?: string
+  csCategory?: string
+}
+
+// 핵심 도메인 모델 - 앱 내부에서 사용하는 기본 타입
 export interface CSQuestion {
   id: number
   question: string
-  bestAnswer: string
+  relatedCode?: string
+  csCategory?: string
+}
+
+// DTO에서 도메인 모델로 변환하는 헬퍼 함수
+export function mapDtoToCSQuestion(dto: CSQuestionDTO): CSQuestion {
+  return {
+    id: dto.questionId,
+    question: dto.question,
+    relatedCode: dto.relatedCode,
+    csCategory: dto.csCategory,
+  }
 }
 
 // 질문 이력 아이템 타입
 export interface QuestionHistoryItem {
   id: number
   question: string
-  codeSnippet?: string
+  relatedCode?: string
   fileName?: string
   status?: string
-  // API 응답에서 가능한 필드
   csQuestionId?: number
   answer?: string
   feedback?: string
-  answered?: boolean
-  concept?: string
   date?: string
   userCode?: string
+  answered?: boolean
 }
 
 // 날짜별 질문 이력 타입

--- a/src/api/services/question/query.ts
+++ b/src/api/services/question/query.ts
@@ -100,7 +100,7 @@ export const getQuestionDetail = async (
       id: data.result.questionId || data.result.id || data.result.csQuestionId,
       question: data.result.question || '',
       codeSnippet: data.result.userCode || '',
-      fileName: data.result.fileName || '',
+
       concept: data.result.concept || '',
       answer: userAnswer || data.result.answer || '',
       feedback: aiAnswer || data.result.feedback || '',

--- a/src/api/services/question/query.ts
+++ b/src/api/services/question/query.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetcher, useGetQuery } from '@/api/lib/fetcher'
 import {
-  CSQuestion,
   CSQuestionResponse,
   CSQuestionListResponse,
   RecentCSQuestionsResponse,

--- a/src/components/DashboardCard/CardContent.tsx
+++ b/src/components/DashboardCard/CardContent.tsx
@@ -3,6 +3,7 @@
 import { Pen, Trash2, Loader2 } from 'lucide-react'
 import { CardType } from './DashboardCard'
 import { useRouter } from 'next/navigation'
+import { formatDate } from '@/utils/updated_date'
 
 interface CardContentProps {
   card: CardType
@@ -25,12 +26,6 @@ export const CardContent = ({
   onCloseError,
 }: CardContentProps) => {
   const router = useRouter()
-
-  // 날짜에서 시간을 제외하고 YYYY. MM. DD 형식으로 변환
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return `${date.getFullYear()}. ${String(date.getMonth() + 1).padStart(2, '0')}. ${String(date.getDate()).padStart(2, '0')}`
-  }
 
   // 상태값 표시 텍스트 변환
   const getStatusText = (status: string) => {

--- a/src/components/DetailProject/code-selection/CodeViewer.tsx
+++ b/src/components/DetailProject/code-selection/CodeViewer.tsx
@@ -2,22 +2,28 @@
 
 import React, { RefObject, useCallback } from 'react'
 import { Textarea } from '@/components/ui/textarea'
+import { generateSkeleton } from '@/lib/skeleton-generator'
 
 interface CodeViewerProps {
   code: string
   selectedCode: string
   codeTextareaRef: RefObject<HTMLTextAreaElement | null>
   onSelectCode: (text: string) => void
+  loading?: boolean
   className?: string
 }
 
-export default function CodeViewer({
+/**
+ * 코드 뷰어 컴포넌트
+ */
+const CodeViewer: React.FC<CodeViewerProps> = ({
   code,
   selectedCode,
   codeTextareaRef,
   onSelectCode,
+  loading = false,
   className = '',
-}: CodeViewerProps) {
+}) => {
   // 텍스트 선택 핸들러
   const handleTextSelection = useCallback(() => {
     if (codeTextareaRef?.current) {
@@ -32,6 +38,7 @@ export default function CodeViewer({
     }
   }, [code, codeTextareaRef, onSelectCode])
 
+  // 코드가 없을 때는 안내 메시지 표시
   if (!code) {
     return (
       <div
@@ -42,6 +49,7 @@ export default function CodeViewer({
     )
   }
 
+  // 코드 표시
   return (
     <Textarea
       ref={codeTextareaRef}
@@ -54,3 +62,53 @@ export default function CodeViewer({
     />
   )
 }
+
+/**
+ * 코드 뷰어 스켈레톤 컴포넌트
+ */
+const CodeViewerSkeleton = generateSkeleton(
+  ({ className = '' }: { className?: string }) => (
+    <div className={`min-h-[300px] rounded-md border p-4 ${className}`}>
+      <div className="animate-pulse space-y-2 font-mono text-sm">
+        {Array.from({ length: 30 }).map((_, index) => {
+          // 들여쓰기 패턴 (3라인마다 들여쓰기 증가)
+          const indentLevel = Math.floor(index / 3) % 4
+          const baseIndent = indentLevel * 5
+
+          // 30% ~ 95% 사이의 랜덤한 너비 + 들여쓰기
+          const width = Math.floor(Math.random() * 65) + 30 + baseIndent
+
+          // 가끔 짧은 라인 (주석, 괄호닫기 등)
+          const finalWidth =
+            index % 7 === 0 ? `${baseIndent + 10}%` : `${Math.min(width, 95)}%`
+
+          return (
+            <div
+              key={index}
+              className="h-4 rounded bg-slate-200"
+              style={{ width: finalWidth }}
+            />
+          )
+        })}
+      </div>
+    </div>
+  ),
+)
+
+/**
+ * 코드 뷰어 래퍼 컴포넌트
+ * 로딩 상태에 따라 실제 컴포넌트 또는 스켈레톤을 표시
+ */
+const CodeViewerWrapper: React.FC<CodeViewerProps> = ({
+  loading = false,
+  className = '',
+  ...props
+}) => {
+  if (loading) {
+    return <CodeViewerSkeleton className={className} />
+  }
+
+  return <CodeViewer loading={loading} className={className} {...props} />
+}
+
+export default CodeViewerWrapper

--- a/src/components/DetailProject/code-selection/DateRangePicker.tsx
+++ b/src/components/DetailProject/code-selection/DateRangePicker.tsx
@@ -32,6 +32,16 @@ export default function DateRangePicker({
     dateRange.to ? format(dateRange.to, 'yyyy-MM-dd') : '',
   )
 
+  // 전체기간 설정
+  const handleSelectAllPeriod = () => {
+    const to = new Date()
+    const from = new Date()
+    from.setFullYear(from.getFullYear() - 10) // 10년 전으로 설정
+    onDateRangeChange({ from, to })
+    setFromInputValue(format(from, 'yyyy-MM-dd'))
+    setToInputValue(format(to, 'yyyy-MM-dd'))
+  }
+
   // 기간 단축 버튼
   const handleQuickSelect = (days: number) => {
     const to = new Date()
@@ -80,6 +90,21 @@ export default function DateRangePicker({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          type="button"
+          onClick={handleSelectAllPeriod}
+          className={cn(
+            'text-xs',
+            dateRange.from &&
+              dateRange.from.getFullYear() < new Date().getFullYear() - 5
+              ? 'bg-muted font-medium'
+              : '',
+          )}
+        >
+          전체기간
+        </Button>
         <Button
           variant="outline"
           size="sm"
@@ -133,24 +158,6 @@ export default function DateRangePicker({
           )}
         >
           최근 1개월
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          type="button"
-          onClick={() => handleQuickSelect(90)}
-          className={cn(
-            'text-xs',
-            dateRange.from &&
-              Math.round(
-                (new Date().getTime() - dateRange.from.getTime()) /
-                  (1000 * 60 * 60 * 24),
-              ) === 90
-              ? 'bg-muted font-medium'
-              : '',
-          )}
-        >
-          최근 3개월
         </Button>
       </div>
 

--- a/src/components/DetailProject/code-selection/FileList.tsx
+++ b/src/components/DetailProject/code-selection/FileList.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { Loader2, Folder, FileText, ChevronUp } from 'lucide-react'
 import { FileItem } from '@/api'
+import { generateSkeleton } from '@/lib/skeleton-generator'
 
 interface FileListProps {
   files: FileItem[]
@@ -11,6 +12,7 @@ interface FileListProps {
   loading: boolean
   onSelectFile: (file: FileItem) => void
   onNavigateUp: () => void
+  className?: string
 }
 
 /**
@@ -23,6 +25,7 @@ const FileList: React.FC<FileListProps> = ({
   loading,
   onSelectFile,
   onNavigateUp,
+  className = '',
 }) => {
   // 파일 아이콘 결정 함수
   const getFileIcon = (type: string) => {
@@ -52,7 +55,9 @@ const FileList: React.FC<FileListProps> = ({
   }
 
   return (
-    <div className="h-64 overflow-y-auto rounded-md border border-slate-200">
+    <div
+      className={`h-64 overflow-y-auto rounded-md border border-slate-200 ${className}`}
+    >
       {/* 현재 경로 표시 */}
       <div className="bg-slate-50 p-2 text-sm font-medium text-slate-700">
         <div className="flex items-center">
@@ -93,4 +98,49 @@ const FileList: React.FC<FileListProps> = ({
   )
 }
 
-export default FileList
+/**
+ * 파일 목록 스켈레톤 컴포넌트
+ */
+const FileListSkeleton: React.FC<{ className?: string }> = ({
+  className = '',
+}) => (
+  <div
+    className={`h-64 overflow-y-auto rounded-md border border-slate-200 ${className}`}
+  >
+    <div className="bg-slate-50 p-2 text-sm font-medium text-slate-700">
+      <div className="flex items-center">루트 디렉토리</div>
+    </div>
+    <ul className="divide-y divide-slate-100">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <li key={index} className="p-2">
+          <div className="flex items-center space-x-2">
+            {index % 3 === 0 ? (
+              <Folder className="h-4 w-4 text-blue-500" />
+            ) : (
+              <FileText className="h-4 w-4 text-slate-500" />
+            )}
+            <div className="h-4 w-3/4 animate-pulse rounded bg-slate-200" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+/**
+ * 파일 목록 래퍼 컴포넌트
+ * 로딩 상태에 따라 실제 컴포넌트 또는 스켈레톤을 표시
+ */
+const FileListWrapper: React.FC<FileListProps> = ({
+  loading = false,
+  className = '',
+  ...props
+}) => {
+  if (loading) {
+    return <FileListSkeleton className={className} />
+  }
+
+  return <FileList loading={loading} className={className} {...props} />
+}
+
+export default FileListWrapper

--- a/src/components/DetailProject/code-selection/index.tsx
+++ b/src/components/DetailProject/code-selection/index.tsx
@@ -12,6 +12,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { DateRange } from 'react-day-picker'
 import { FileItem } from '@/api'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 interface CodeSelectionTabProps {
   projectId: string
@@ -27,6 +34,9 @@ export default function CodeSelectionTab({
   const {
     dateRange,
     handleDateRangeChange,
+    selectedBranch,
+    availableBranches,
+    handleBranchChange,
     files,
     currentPath,
     selectedFile,
@@ -101,6 +111,28 @@ export default function CodeSelectionTab({
                 <p className="text-muted-foreground mb-4 text-sm">
                   특정 기간에 변경된 파일만 보려면 날짜 범위를 선택하세요.
                 </p>
+
+                <div className="mb-4">
+                  <label className="mb-1 block text-sm font-medium">
+                    브랜치 선택
+                  </label>
+                  <Select
+                    value={selectedBranch}
+                    onValueChange={handleBranchChange}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="브랜치 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableBranches.map((branch) => (
+                        <SelectItem key={branch} value={branch}>
+                          {branch}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
                 <DateRangePicker
                   dateRange={dateRange}
                   onDateRangeChange={handleDateChange}

--- a/src/components/DetailProject/code-selection/index.tsx
+++ b/src/components/DetailProject/code-selection/index.tsx
@@ -72,15 +72,16 @@ export default function CodeSelectionTab({
         <Info className="h-5 w-5 text-blue-500" />
         <AlertTitle className="font-medium text-blue-700">시작하기</AlertTitle>
         <AlertDescription className="text-blue-600">
-          코드를 분석하여 CS 질문을 생성하려면 날짜 범위를 선택하고, 파일을
-          선택한 다음 코드 영역을 선택해 주세요.
+          코드를 분석하여 CS 질문을 생성하려면 파일을 선택하고 분석할 코드
+          영역을 선택해 주세요. 필요한 경우 날짜 범위를 지정하여 특정 기간 동안
+          변경된 파일만 조회할 수 있습니다.
         </AlertDescription>
       </Alert>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         <TabsList className="mb-4 grid w-full grid-cols-2 md:w-[400px]">
           <TabsTrigger value="calendar" className="flex items-center gap-2">
-            1. 날짜 및 파일 선택
+            1. 파일 선택
           </TabsTrigger>
           <TabsTrigger
             value="code"
@@ -95,9 +96,11 @@ export default function CodeSelectionTab({
           <div className="grid gap-6 md:grid-cols-2">
             <Card>
               <CardContent className="p-6">
-                <h3 className="mb-2 text-lg font-semibold">날짜 범위 선택</h3>
+                <h3 className="mb-2 text-lg font-semibold">
+                  파일 필터링 (선택사항)
+                </h3>
                 <p className="text-muted-foreground mb-4 text-sm">
-                  조회할 커밋 기간을 선택해주세요.
+                  특정 기간에 변경된 파일만 보려면 날짜 범위를 선택하세요.
                 </p>
                 <DateRangePicker
                   dateRange={dateRange}
@@ -109,7 +112,14 @@ export default function CodeSelectionTab({
                     onClick={fetchCommitsAndFiles}
                     className="bg-primary hover:bg-primary/90"
                   >
-                    파일 가져오기
+                    {loading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        불러오는 중...
+                      </>
+                    ) : (
+                      '파일 필터링 적용'
+                    )}
                   </Button>
                 </div>
               </CardContent>
@@ -117,7 +127,7 @@ export default function CodeSelectionTab({
 
             <Card>
               <CardContent className="p-6">
-                <h3 className="mb-2 text-lg font-semibold">파일 선택</h3>
+                <h3 className="mb-2 text-lg font-semibold">파일 목록</h3>
                 <p className="text-muted-foreground mb-4 text-sm">
                   분석할 코드가 포함된 파일을 선택해주세요.
                 </p>
@@ -131,7 +141,7 @@ export default function CodeSelectionTab({
                   </div>
                 ) : files.length === 0 ? (
                   <div className="bg-muted rounded-md border p-4 text-sm">
-                    날짜 범위를 선택하고 파일을 가져와주세요.
+                    파일 목록을 가져오는 중입니다...
                   </div>
                 ) : (
                   <FileList

--- a/src/components/DetailProject/code-selection/index.tsx
+++ b/src/components/DetailProject/code-selection/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Info } from 'lucide-react'
 import DateRangePicker from './DateRangePicker'
 import FileList from './FileList'
 import CodeViewer from './CodeViewer'
@@ -10,7 +10,6 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { Info } from 'lucide-react'
 import { DateRange } from 'react-day-picker'
 import { FileItem } from '@/api'
 
@@ -135,13 +134,9 @@ export default function CodeSelectionTab({
                   <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
                     {error}
                   </div>
-                ) : loading ? (
-                  <div className="flex justify-center p-10">
-                    <Loader2 className="text-primary h-6 w-6 animate-spin" />
-                  </div>
-                ) : files.length === 0 ? (
+                ) : files.length === 0 && !loading ? (
                   <div className="bg-muted rounded-md border p-4 text-sm">
-                    파일 목록을 가져오는 중입니다...
+                    파일이 없습니다. 날짜 범위를 변경해보세요.
                   </div>
                 ) : (
                   <FileList
@@ -181,8 +176,9 @@ export default function CodeSelectionTab({
                 <CodeViewer
                   code={code}
                   selectedCode={selectedCode}
-                  onSelectCode={handleSelectCode}
                   codeTextareaRef={codeTextareaRef}
+                  onSelectCode={handleSelectCode}
+                  loading={loading}
                   className="min-h-[400px] md:min-h-[500px]"
                 />
               </div>

--- a/src/components/DetailProject/cs-questions/AnswerForm.tsx
+++ b/src/components/DetailProject/cs-questions/AnswerForm.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 interface AnswerFormProps {
   question: string
   codeSnippet?: string
+  relatedCode?: string
   questionIndex?: number
   totalQuestions?: number
   answer: string
@@ -23,7 +24,7 @@ interface AnswerFormProps {
 
 export default function AnswerForm({
   question,
-  codeSnippet = '',
+  relatedCode = '',
   questionIndex = 1,
   totalQuestions = 1,
   answer,
@@ -76,17 +77,14 @@ export default function AnswerForm({
         <div className="bg-card rounded-lg border p-4">
           <h3 className="font-medium">{question}</h3>
 
-          {codeSnippet && (
+          {relatedCode && (
             <div className="mt-3 space-y-1">
               <div className="text-muted-foreground flex items-center gap-1 text-xs">
                 <Code className="h-3.5 w-3.5" />
                 <span>관련 코드</span>
               </div>
               <pre className="bg-muted overflow-auto rounded-md p-2 text-xs">
-                {codeSnippet.length > 300
-                  ? codeSnippet.substring(0, 300) + '...'
-                  : codeSnippet}
-                {/* todo 선택한 코드 중 ai가 질문과 관련된 코드만 선택하여 제공하게 수정 필요 */}
+                {relatedCode}
               </pre>
             </div>
           )}

--- a/src/components/DetailProject/cs-questions/index.tsx
+++ b/src/components/DetailProject/cs-questions/index.tsx
@@ -205,7 +205,7 @@ const CSQuestionsTab: React.FC<CSQuestionsTabProps> = ({
                   {selectedQuestion ? (
                     <AnswerForm
                       question={selectedQuestion.question}
-                      codeSnippet={selectedQuestion.codeSnippet}
+                      relatedCode={selectedQuestion.relatedCode}
                       questionIndex={currentQuestionIndex}
                       totalQuestions={questions.length}
                       answer={answer}

--- a/src/components/DetailProject/cs-questions/useCSQuestions.ts
+++ b/src/components/DetailProject/cs-questions/useCSQuestions.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { QuestionItem } from '../types'
-import { generateCSQuestions } from '@/api'
+import { generateCodeCSQuestions } from '@/api'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { CSQuestion } from '@/api'
 
@@ -61,7 +61,7 @@ export default function useCSQuestions({
     error,
   } = useQuery<CSQuestion[]>({
     queryKey: ['csQuestions', projectId, codeSnippet, folderName],
-    queryFn: () => generateCSQuestions(projectId, codeSnippet, folderName),
+    queryFn: () => generateCodeCSQuestions(projectId, codeSnippet, folderName),
     enabled: !!projectId && !!codeSnippet,
     staleTime: 1000 * 60 * 30, // 30분간 데이터 유지
     gcTime: 1000 * 60 * 60, // 60분간 캐시 유지
@@ -106,7 +106,6 @@ export default function useCSQuestions({
         answered: false, // 기본값은 미답변
         userAnswer: '',
         feedback: '',
-        codeSnippet: codeSnippet.substring(0, 100) + '...',
         folderName: folderName, // folderName 저장
       }))
 

--- a/src/components/DetailProject/question-history/HistoryList.tsx
+++ b/src/components/DetailProject/question-history/HistoryList.tsx
@@ -138,7 +138,6 @@ const HistoryList: React.FC<HistoryListProps> = ({
                                     id: questionId,
                                     question:
                                       question.question || '질문 내용 없음',
-                                    fileName: (question as any).fileName || '',
                                     folderName:
                                       (question as any).folderName || '',
                                   })

--- a/src/components/DetailProject/question-history/HistoryList.tsx
+++ b/src/components/DetailProject/question-history/HistoryList.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { HistoryByDate, QuestionHistoryItem } from '../types'
+import { HistoryByDate, UIQuestionHistoryItem } from '../types'
 import QuestionCard from '../ui/QuestionCard'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 
@@ -10,8 +10,8 @@ interface HistoryListProps {
   history: HistoryByDate
   selectedQuestionId?: number
   bookmarkedQuestions: number[]
-  onSelectQuestion: (question: QuestionHistoryItem) => void
-  onAnswer?: (question: QuestionHistoryItem) => void
+  onSelectQuestion: (question: UIQuestionHistoryItem) => void
+  onAnswer?: (question: UIQuestionHistoryItem) => void
 }
 
 /**
@@ -104,7 +104,7 @@ const HistoryList: React.FC<HistoryListProps> = ({
                         id: questionId,
                         answered: isAnswered,
                         question: question.question || '질문 내용 없음',
-                        codeSnippet: question.codeSnippet || '',
+                        relatedCode: (question as any).relatedCode || '',
                         folderName: (question as any).folderName || '',
                         status: isDone ? 'DONE' : 'TODO',
                         userAnswer: question.answer || '',

--- a/src/components/DetailProject/question-history/QuestionDetail.tsx
+++ b/src/components/DetailProject/question-history/QuestionDetail.tsx
@@ -3,15 +3,16 @@
 import React, { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { QuestionHistoryItem } from '../types'
+import { UIQuestionHistoryItem } from '../types'
 import { FileCode, MessageSquareText, Loader2, AlertCircle } from 'lucide-react'
+import { Code } from 'lucide-react'
 
 interface QuestionDetailProps {
-  question: QuestionHistoryItem | null
+  question: UIQuestionHistoryItem | null
   isBookmarked: boolean
   onBookmark: (questionId: number) => void
   onAnswer?: (
-    question: QuestionHistoryItem,
+    question: UIQuestionHistoryItem,
     answer: string,
   ) => Promise<string | undefined>
   activeCSQuestionIds?: number[] // CS 질문 탭에서 활성화된 질문 ID 목록
@@ -91,11 +92,14 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
             <span>{question.fileName}</span>
           </div>
         )}
-
-        {question.codeSnippet && (
+        <div className="text-muted-foreground flex items-center gap-1 text-xs">
+          <Code className="h-3.5 w-3.5" />
+          <span>관련 코드</span>
+        </div>
+        {question.relatedCode && (
           <div className="mt-2 overflow-auto rounded-md bg-slate-100 p-3">
             <pre className="text-xs whitespace-pre-wrap text-slate-700">
-              {question.codeSnippet}
+              {question.relatedCode}
             </pre>
           </div>
         )}

--- a/src/components/DetailProject/question-history/QuestionDetail.tsx
+++ b/src/components/DetailProject/question-history/QuestionDetail.tsx
@@ -86,13 +86,24 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
       <div className="mb-4">
         <h3 className="font-medium text-slate-800">{question.question}</h3>
 
-        {question.fileName && (
-          <div className="mt-2 flex items-center text-xs text-blue-600">
-            <FileCode className="mr-1 h-4 w-4" />
-            <span>{question.fileName}</span>
+        {question.folderName && (
+          <div className="mt-2 flex items-center justify-between text-xs">
+            <div className="flex items-center text-blue-600">
+              <FileCode className="mr-1 h-4 w-4" />
+              <span>{question.folderName}</span>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-xs"
+              onClick={() => onBookmark(question.id)}
+              disabled={isBookmarked}
+            >
+              {isBookmarked ? '북마크됨' : '북마크 추가'}
+            </Button>
           </div>
         )}
-        <div className="text-muted-foreground flex items-center gap-1 text-xs">
+        <div className="text-muted-foreground mt-3 flex items-center gap-1 text-xs">
           <Code className="h-3.5 w-3.5" />
           <span>관련 코드</span>
         </div>
@@ -103,18 +114,6 @@ const QuestionDetail: React.FC<QuestionDetailProps> = ({
             </pre>
           </div>
         )}
-
-        <div className="mt-3 flex justify-end space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-xs"
-            onClick={() => onBookmark(question.id)}
-            disabled={isBookmarked}
-          >
-            {isBookmarked ? '북마크됨' : '북마크 추가'}
-          </Button>
-        </div>
       </div>
 
       <div className="mt-6 space-y-4">

--- a/src/components/DetailProject/question-history/useQuestionHistory.ts
+++ b/src/components/DetailProject/question-history/useQuestionHistory.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { getCSQuestionHistory, getQuestionDetail } from '@/api'
-import { HistoryByDate, QuestionHistoryItem } from '../types'
+import { HistoryByDate, UIQuestionHistoryItem } from '../types'
 
 interface UseQuestionHistoryProps {
   projectId: string
@@ -12,7 +12,7 @@ interface UseQuestionHistoryProps {
 
 // 정규화된 데이터 구조를 위한 인터페이스
 interface NormalizedQuestions {
-  byId: Record<number, QuestionHistoryItem>
+  byId: Record<number, UIQuestionHistoryItem>
   byDate: Record<string, number[]>
   allDates: string[]
 }
@@ -30,7 +30,7 @@ export default function useQuestionHistory({
       }
 
       // 초기 데이터 정규화
-      const byId: Record<number, QuestionHistoryItem> = {}
+      const byId: Record<number, UIQuestionHistoryItem> = {}
       const byDate: Record<string, number[]> = {}
       const allDates = Object.keys(initialHistory).sort(
         (a, b) => new Date(b).getTime() - new Date(a).getTime(),
@@ -40,7 +40,7 @@ export default function useQuestionHistory({
         const questions = initialHistory[date] || []
         byDate[date] = []
 
-        questions.forEach((question) => {
+        questions.forEach((question: UIQuestionHistoryItem) => {
           const id = (question as any).questionId || question.id || 0
           if (id) {
             byId[id] = question
@@ -71,7 +71,7 @@ export default function useQuestionHistory({
 
   // 메모이제이션된 현재 질문 (상세 정보 포함)
   const [currentQuestion, setCurrentQuestion] =
-    useState<QuestionHistoryItem | null>(null)
+    useState<UIQuestionHistoryItem | null>(null)
 
   // 메모이제이션된 날짜 정렬 (최신순)
   const sortedDates = useMemo(
@@ -97,7 +97,7 @@ export default function useQuestionHistory({
             codeSnippet: question.codeSnippet || '',
           }
         })
-        .filter(Boolean) as QuestionHistoryItem[]
+        .filter(Boolean) as UIQuestionHistoryItem[]
     })
 
     return result
@@ -114,7 +114,7 @@ export default function useQuestionHistory({
         const data = await getCSQuestionHistory(projectId)
 
         // 받아온 데이터 정규화
-        const byId: Record<number, QuestionHistoryItem> = {}
+        const byId: Record<number, UIQuestionHistoryItem> = {}
         const byDate: Record<string, number[]> = {}
         const allDates = Object.keys(data).sort(
           (a, b) => new Date(b).getTime() - new Date(a).getTime(),
@@ -124,7 +124,7 @@ export default function useQuestionHistory({
           const questions = data[date] || []
           byDate[date] = []
 
-          questions.forEach((question) => {
+          questions.forEach((question: UIQuestionHistoryItem) => {
             const id = (question as any).questionId || question.id || 0
             if (id) {
               byId[id] = question
@@ -146,7 +146,7 @@ export default function useQuestionHistory({
 
   // 질문 선택 핸들러 - 상세 정보 API 호출 추가
   const handleSelectQuestion = useCallback(
-    async (question: QuestionHistoryItem | null) => {
+    async (question: UIQuestionHistoryItem | null) => {
       if (!question) {
         setCurrentQuestion(null)
         setSelectedQuestionId(null)
@@ -163,7 +163,7 @@ export default function useQuestionHistory({
           ...question,
           question: question.question || '',
           answer: question.answer || '',
-          codeSnippet: question.codeSnippet || '',
+          relatedCode: question.relatedCode || '',
           feedback: question.feedback || '',
         })
 
@@ -193,7 +193,7 @@ export default function useQuestionHistory({
       const data = await getCSQuestionHistory(projectId)
 
       // 받아온 데이터 정규화
-      const byId: Record<number, QuestionHistoryItem> = {}
+      const byId: Record<number, UIQuestionHistoryItem> = {}
       const byDate: Record<string, number[]> = {}
       const allDates = Object.keys(data).sort(
         (a, b) => new Date(b).getTime() - new Date(a).getTime(),
@@ -203,7 +203,7 @@ export default function useQuestionHistory({
         const questions = data[date] || []
         byDate[date] = []
 
-        questions.forEach((question) => {
+        questions.forEach((question: UIQuestionHistoryItem) => {
           const id = (question as any).questionId || question.id || 0
           if (id) {
             byId[id] = question
@@ -224,7 +224,7 @@ export default function useQuestionHistory({
 
   // 개별 질문 업데이트 - 최적화된 업데이트 로직
   const updateQuestion = useCallback(
-    (questionId: number, updates: Partial<QuestionHistoryItem>) => {
+    (questionId: number, updates: Partial<UIQuestionHistoryItem>) => {
       setQuestionsData((prevData) => {
         // 해당 질문이 존재하지 않으면 변경 없음
         if (!prevData.byId[questionId]) return prevData
@@ -247,7 +247,9 @@ export default function useQuestionHistory({
 
       // 현재 선택된 질문이 업데이트 대상이면 현재 질문도 업데이트
       if (selectedQuestionId === questionId) {
-        setCurrentQuestion((prev) => (prev ? { ...prev, ...updates } : null))
+        setCurrentQuestion((prev: UIQuestionHistoryItem | null) =>
+          prev ? { ...prev, ...updates } : null,
+        )
       }
     },
     [selectedQuestionId],

--- a/src/components/DetailProject/types.ts
+++ b/src/components/DetailProject/types.ts
@@ -46,7 +46,6 @@ export interface CodeSelectionTabProps extends TabProps {
 
 // UI 기본 질문 타입 (도메인 모델 확장)
 export interface BaseQuestion extends DomainCSQuestion {
-  fileName?: string
   folderName?: string
   status?: string
   codeSnippet?: string

--- a/src/components/DetailProject/types.ts
+++ b/src/components/DetailProject/types.ts
@@ -1,9 +1,15 @@
 import {
   Project,
-  HistoryByDate as ImportedHistoryByDate,
+  HistoryByDate as DomainHistoryByDate,
+  CSQuestion as DomainCSQuestion,
 } from '@/api/services/project/model'
 
-// 프로젝트 데이터 타입
+// HistoryByDate 재익스포트
+export type HistoryByDate = DomainHistoryByDate
+
+// =============== 프로젝트 관련 UI 타입 ===============
+
+// 프로젝트 데이터 (도메인 모델 확장)
 export interface ProjectData extends Project {}
 
 // 프로젝트 상세 페이지 props
@@ -20,42 +26,61 @@ export interface ProjectHeaderProps {
   onDelete?: () => void
 }
 
-// 코드 선택 탭 props
-export interface CodeSelectionTabProps {
+// =============== 탭 관련 UI 타입 ===============
+
+// 탭 컴포넌트 공통 속성
+export interface TabProps {
   projectId: string
-  files?: string[]
-  onSelectCodeSnippet: (snippet: string, folderName: string) => void
+  onTabChange?: (tabId: string) => void
 }
 
-// CS 질문 관련 타입 (공통 속성)
-interface BaseQuestion {
-  id: number
-  question: string
-  codeSnippet?: string
+// 코드 선택 탭 props
+export interface CodeSelectionTabProps extends TabProps {
+  files?: string[]
+  onSelectCodeSnippet: (snippet: string, folderName: string) => void
+  onSelectedCode?: (code: string) => void
+  onFinish?: () => void
+}
+
+// =============== CS 질문 관련 UI 타입 ===============
+
+// UI 기본 질문 타입 (도메인 모델 확장)
+export interface BaseQuestion extends DomainCSQuestion {
   fileName?: string
   folderName?: string
   status?: string
+  codeSnippet?: string
 }
 
-// CS 질문 관련 타입
+// 질문 목록 표시에 사용되는 타입
 export interface QuestionItem extends BaseQuestion {
-  bestAnswer?: string
   answered?: boolean
   userAnswer?: string
   feedback?: string
 }
 
+// UI용 질문 이력 아이템 타입 (도메인 모델 확장)
+export interface UIQuestionHistoryItem extends BaseQuestion {
+  answer?: string
+  feedback?: string
+  answered?: boolean
+  createdAt?: string
+  questionId?: number
+  csQuestionId?: number
+  [key: string]: any
+}
+
 // CS 질문 탭 props
-export interface CSQuestionsTabProps {
-  projectId: string
+export interface CSQuestionsTabProps extends TabProps {
+  relatedCode?: string
   codeSnippet?: string
   folderName?: string
   onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
   onSaveQuestion?: (questionId: number) => Promise<boolean | undefined>
+  onQuestionsLoad?: (questions: any[]) => void
   onChooseAnotherCode?: () => void
   onGenerateMoreQuestions?: () => void
   onFinish?: () => void
-  onTabChange?: (tabId: string) => void
 }
 
 // 질문 이력 탭 props
@@ -69,7 +94,9 @@ export interface QuestionHistoryTabProps {
   activeCSQuestionIds?: number[]
 }
 
-// 재사용 가능한 UI 컴포넌트 props
+// =============== 공통 UI 컴포넌트 타입 ===============
+
+// 코드 스니펫 뷰어 props
 export interface CodeSnippetViewerProps {
   code: string
   title?: string
@@ -78,6 +105,7 @@ export interface CodeSnippetViewerProps {
   current?: number
 }
 
+// 질문 카드 props
 export interface QuestionCardProps {
   question: QuestionItem
   isSelected?: boolean
@@ -86,40 +114,4 @@ export interface QuestionCardProps {
   statusColor?: 'green' | 'yellow' | 'red' | 'blue'
   onClick?: () => void
   onAnswer?: (question: QuestionItem) => void
-}
-
-// 질문 이력 아이템 기본 타입
-export interface QuestionHistoryItem extends BaseQuestion {
-  answer?: string
-  feedback?: string
-  answered?: boolean
-  createdAt?: string
-  questionId?: number
-  csQuestionId?: number
-
-  [key: string]: any
-}
-
-// 날짜별 질문 이력 타입
-export interface HistoryByDate extends ImportedHistoryByDate {}
-
-// 탭 컴포넌트 공통 속성
-export interface TabProps {
-  projectId: string
-  onTabChange?: (tabId: string) => void
-}
-
-// CS 질문 탭 컴포넌트 속성
-export interface CSQuestionsTabProps extends TabProps {
-  codeSnippet?: string
-  folderName?: string
-  onAnswerSubmit?: (answer: string, questionId: number) => Promise<string>
-  onSaveQuestion?: (questionId: number) => Promise<boolean | undefined>
-  onQuestionsLoad?: (questions: any[]) => void
-}
-
-// 코드 선택 탭 컴포넌트 속성
-export interface CodeSelectionTabProps extends TabProps {
-  onSelectedCode?: (code: string) => void
-  onFinish?: () => void
 }

--- a/src/components/DetailProject/ui/ProjectHeader.tsx
+++ b/src/components/DetailProject/ui/ProjectHeader.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { Edit3, Trash2 } from 'lucide-react'
 import { ProjectHeaderProps } from '../types'
+import { formatDate } from '@/utils/updated_date'
 
 /**
  * 프로젝트 헤더 컴포넌트
@@ -57,7 +58,7 @@ const ProjectHeader: React.FC<ProjectHeaderProps> = ({
 
       {project.updatedAt && (
         <div className="text-xs text-gray-600">
-          최근 업데이트: {project.updatedAt}
+          최근 업데이트: {formatDate(project.updatedAt)}
         </div>
       )}
 

--- a/src/components/DetailProject/ui/QuestionCard.tsx
+++ b/src/components/DetailProject/ui/QuestionCard.tsx
@@ -46,12 +46,10 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
         )}
       </div>
 
-      {(question.fileName || question.folderName) && (
+      {question.folderName && (
         <div className="mt-2 flex items-center text-xs text-blue-600">
           <FileCode className="mr-1 h-3 w-3" />
-          <span className="truncate">
-            {question.fileName || question.folderName}
-          </span>
+          <span className="truncate">{question.folderName}</span>
         </div>
       )}
 

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/lib/utils'
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string
+  /**
+   * 스켈레톤 높이 (픽셀 또는 Tailwind 클래스)
+   */
+  height?: string | number
+  /**
+   * 스켈레톤 너비 (픽셀 또는 Tailwind 클래스)
+   */
+  width?: string | number
+  /**
+   * 원형 스켈레톤 여부
+   */
+  circle?: boolean
+}
+
+/**
+ * 로딩 상태를 시각적으로 표현하는 스켈레톤 컴포넌트
+ * 다양한 크기와 모양으로 쉽게 커스터마이징할 수 있습니다.
+ *
+ * @example
+ * <Skeleton /> // 기본 직사각형
+ * <Skeleton width={100} height={24} /> // 크기 지정
+ * <Skeleton circle width={40} /> // 원형 아바타 스켈레톤
+ * <Skeleton className="h-6 w-12 rounded-md" /> // Tailwind 클래스 사용
+ */
+const Skeleton = ({
+  className,
+  height,
+  width,
+  circle = false,
+  ...props
+}: SkeletonProps) => {
+  const styleProps: React.CSSProperties = {}
+
+  if (height !== undefined) {
+    styleProps.height = typeof height === 'number' ? `${height}px` : height
+  }
+
+  if (width !== undefined) {
+    styleProps.width = typeof width === 'number' ? `${width}px` : width
+  }
+
+  return (
+    <div
+      className={cn(
+        'bg-muted/60 animate-pulse rounded',
+        circle && 'rounded-full',
+        className,
+      )}
+      style={styleProps}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/lib/skeleton-generator.ts
+++ b/src/lib/skeleton-generator.ts
@@ -1,0 +1,230 @@
+import React, {
+  ElementType,
+  ReactElement,
+  ReactNode,
+  cloneElement,
+  isValidElement,
+} from 'react'
+import { type ClassValue, cn } from '@/lib/utils'
+
+type SkeletonOptions = {
+  /**
+   * 스켈레톤에서 제외할 클래스 패턴 목록
+   */
+  excludeClasses?: string[]
+  /**
+   * 루트 요소에서 제외할 클래스 패턴 목록
+   */
+  rootExcludeClasses?: string[]
+  /**
+   * 스켈레톤 효과를 적용할 클래스 목록
+   */
+  skeletonClasses?: ClassValue[]
+  /**
+   * 스켈레톤으로 변환할 태그 목록
+   */
+  skeletonizeTags?: string[]
+  /**
+   * 스켈레톤에서 텍스트를 유지할지 여부
+   */
+  preserveText?: boolean
+  /**
+   * 스켈레톤 높이 (픽셀)
+   */
+  skeletonHeight?: number
+}
+
+/**
+ * 기본 스켈레톤 설정
+ */
+const DEFAULT_OPTIONS: SkeletonOptions = {
+  excludeClasses: [
+    'hover',
+    'focus',
+    'active',
+    'transition',
+    'transform',
+    'animate',
+    'cursor',
+  ],
+  rootExcludeClasses: [],
+  skeletonClasses: ['animate-pulse', 'bg-slate-200', 'rounded'],
+  skeletonizeTags: [
+    'span',
+    'p',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'a',
+    'button',
+    'img',
+  ],
+  preserveText: false,
+  skeletonHeight: 16,
+}
+
+/**
+ * 클래스명 필터링 함수
+ */
+const filterClassNames = (
+  classNames: string,
+  excludePatterns: string[] = [],
+  isRoot = false,
+  rootExcludePatterns: string[] = [],
+): string => {
+  if (!classNames) return ''
+
+  const classes = classNames.split(' ')
+  const filteredClasses = classes.filter((cls) => {
+    // 루트 요소인 경우 루트 제외 패턴도 확인
+    if (isRoot) {
+      if (rootExcludePatterns.some((pattern) => cls.includes(pattern))) {
+        return false
+      }
+    }
+
+    // 공통 제외 패턴 확인
+    return !excludePatterns.some((pattern) => cls.includes(pattern))
+  })
+
+  return filteredClasses.join(' ')
+}
+
+/**
+ * 요소를 스켈레톤으로 변환하는 함수
+ */
+const transformToSkeleton = (
+  element: ReactNode,
+  options: SkeletonOptions = DEFAULT_OPTIONS,
+  isRoot = false,
+): ReactNode => {
+  if (!isValidElement(element)) {
+    // 텍스트 노드인 경우 제거하거나 유지
+    if (typeof element === 'string' || typeof element === 'number') {
+      return options.preserveText ? element : null
+    }
+    return element
+  }
+
+  // 타입 단언으로 element의 props 접근 처리
+  const props = element.props as Record<string, any>
+  const { children, className, ...restProps } = props
+
+  // 태그 이름 확인
+  const type = element.type
+  const tagName = typeof type === 'string' ? type : 'div'
+
+  // 스켈레톤화할 태그인지 확인
+  const shouldSkeletonize = options.skeletonizeTags?.includes(tagName)
+
+  // 클래스명 필터링
+  const filteredClassName = className
+    ? filterClassNames(
+        className,
+        options.excludeClasses || [],
+        isRoot,
+        options.rootExcludeClasses || [],
+      )
+    : ''
+
+  // 자식 요소 변환
+  const transformedChildren = React.Children.map(children, (child) =>
+    transformToSkeleton(child, options, false),
+  )
+
+  // 스켈레톤화해야 하는 태그이면 스켈레톤 클래스 적용
+  if (shouldSkeletonize) {
+    const skeletonClassName = cn(
+      filteredClassName,
+      options.skeletonClasses,
+      'inline-block',
+    )
+
+    return React.createElement('div', {
+      className: skeletonClassName,
+      style: { height: `${options.skeletonHeight}px` },
+      ...restProps,
+    })
+  }
+
+  // 기존 요소 복제하되 필터링된 클래스와 변환된 자식 요소 적용
+  return cloneElement(
+    element,
+    {
+      ...restProps,
+      className: filteredClassName ? filteredClassName : undefined,
+    } as React.ClassAttributes<unknown> & Record<string, any>,
+    transformedChildren,
+  )
+}
+
+/**
+ * 컴포넌트를 스켈레톤으로 변환하는 함수
+ */
+export function generateSkeleton<P extends object>(
+  Component: ElementType<P>,
+  options?: SkeletonOptions,
+): React.FC<Partial<P>> {
+  const SkeletonComponent: React.FC<Partial<P>> = (props) => {
+    try {
+      // 원본 컴포넌트 렌더링
+      const renderedComponent = React.createElement(Component, props as P)
+
+      // 스켈레톤으로 변환
+      return transformToSkeleton(
+        renderedComponent,
+        { ...DEFAULT_OPTIONS, ...options },
+        true,
+      ) as ReactElement
+    } catch (error) {
+      console.error('Error generating skeleton:', error)
+      // 오류 발생 시 fallback 스켈레톤 반환
+      return React.createElement('div', {
+        className: 'w-full h-32 animate-pulse bg-slate-200 rounded',
+      })
+    }
+  }
+
+  // 디버깅을 위한 displayName 설정
+  const componentName =
+    typeof Component === 'function'
+      ? Component.name
+      : typeof Component === 'object' && Component !== null
+        ? (Component as any).displayName
+        : 'Component'
+
+  SkeletonComponent.displayName = `Skeleton(${componentName})`
+
+  return SkeletonComponent
+}
+
+/**
+ * 기본 스켈레톤 박스 컴포넌트
+ */
+export function SkeletonBox({
+  width,
+  height = 16,
+  className,
+}: {
+  width?: string | number
+  height?: string | number
+  className?: string
+}) {
+  const styleProps: React.CSSProperties = {}
+
+  if (height !== undefined) {
+    styleProps.height = typeof height === 'number' ? `${height}px` : height
+  }
+
+  if (width !== undefined) {
+    styleProps.width = typeof width === 'number' ? `${width}px` : width
+  }
+
+  return React.createElement('div', {
+    className: cn('animate-pulse bg-slate-200 rounded', className),
+    style: styleProps,
+  })
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,13 @@
 import { clsx, type ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
+/**
+ * 여러 클래스 이름을 병합하는 유틸리티 함수
+ * clsx로 클래스를 결합하고 tailwind-merge로 충돌을 해결합니다.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// ClassValue 타입 내보내기
+export type { ClassValue }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,9 @@
+/**
+ * 날짜를 'YYYY. MM. DD' 형식으로 포맷팅하는 함수
+ * @param dateString - ISO 형식의 날짜 문자열
+ * @returns 포맷팅된 날짜 문자열 (YYYY. MM. DD)
+ */
+export const formatDate = (dateString: string) => {
+  const date = new Date(dateString)
+  return `${date.getFullYear()}. ${String(date.getMonth() + 1).padStart(2, '0')}. ${String(date.getDate()).padStart(2, '0')}`
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,9 +1,0 @@
-/**
- * 날짜를 'YYYY. MM. DD' 형식으로 포맷팅하는 함수
- * @param dateString - ISO 형식의 날짜 문자열
- * @returns 포맷팅된 날짜 문자열 (YYYY. MM. DD)
- */
-export const formatDate = (dateString: string) => {
-  const date = new Date(dateString)
-  return `${date.getFullYear()}. ${String(date.getMonth() + 1).padStart(2, '0')}. ${String(date.getDate()).padStart(2, '0')}`
-}

--- a/src/utils/updated_date.ts
+++ b/src/utils/updated_date.ts
@@ -1,0 +1,9 @@
+/**
+ * 날짜를 'YYYY. MM. DD' 형식으로 포맷팅하는 함수
+ * @param dateString - ISO 형식의 날짜 문자열
+ * @returns 포맷팅된 날짜 문자열 (YYYY. MM. DD)
+ */
+export const formatDate = (dateString: string) => {
+  const date = new Date(dateString)
+  return `${date.getFullYear()}. ${String(date.getMonth() + 1).padStart(2, '0')}. ${String(date.getDate()).padStart(2, '0')}`
+}


### PR DESCRIPTION
## 📌 관련 이슈

- 이슈 번호: #32 

## 💡 작업 내용

<!-- 이번 PR에서 작업한 내용을 자세히 설명해주세요 -->
- 파일 선택 시 날짜별 커밋 필터링 기능 구현
- 커밋/파일 변경 이력 수집 로직 최적화
- 브랜치 선택 기능 추가
- Skeleton UI 및 Skeleton 제너레이터 도입

## ✨ 주요 변경점

<!-- 핵심적인 변경 사항들을 나열해주세요 -->

- [x] 기간 필터링 기능 및 변경 파일만 추출하는 커밋 분석 로직 구현
- 사용자가 기간을 선택하면, 해당 기간 내에 변경된 파일만 추출하여 파일 목록에 노출합니다.
- GitHub 커밋 API를 활용해 중복 없이 변경 파일 경로를 수집하며, 전체 파일이 아닌 실제로 변경된 파일만 보여줍니다.
- [x] 커밋/파일 변경 이력 수집 로직 최적화 (페이지네이션, 병렬 처리, 에러 핸들링, 중복 제거)
- 커밋이 100개를 초과할 경우 페이지네이션(page 파라미터)으로 모든 커밋을 누락 없이 반복 수집합니다.
- 각 커밋의 변경 파일 목록 fetch를 병렬(Promise.all)로 처리하여 전체 속도를 개선했습니다.
- 일부 커밋 상세 요청이 실패해도 전체 흐름은 중단되지 않고, 가능한 데이터만 최대한 수집합니다.
- Set 자료구조로 파일 경로 기준 중복을 제거하여, 동일 파일명/경로는 한 번만 노출됩니다.
- [x] develop/main 등 브랜치 선택 드롭다운 UI 및 최신 파일 상태 제공
- 코드 선택 화면에서 develop/main 등 원하는 브랜치를 선택할 수 있도록 드롭다운 UI를 추가했습니다.
- 파일 목록에서 파일을 선택하면, 항상 현재 브랜치(HEAD 기준)의 최신 상태 파일 내용을 제공합니다.
- [x] 파일 리스트, 코드 뷰어 등 주요 영역에 Skeleton UI 및 Skeleton 제너레이터 적용
- 파일 리스트, 코드 뷰어 등 주요 데이터 로딩 구간에 Skeleton 컴포넌트를 적용했습니다.
- 기존에는 단순 스피너만 표시되었으나, Skeleton UI를 통해 실제 레이아웃과 유사한 형태로 미리 공간을 확보하여, 사용자가 어떤 정보가 곧 표시될지 예측할 수 있도록 했습니다.
- Skeleton 제너레이터 유틸을 도입하여, 파일 목록 등 반복되는 영역에 Skeleton 컴포넌트를 동적으로 여러 개 렌더링할 수 있도록 구현했습니다



## ✅ 셀프 체크리스트

<!-- PR을 제출하기 전에 아래 항목들을 확인해주세요 -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
