### PR TITLE
fix: 북마크 csQuestionId 추가, API 수정

### DIFF
--- a/src/api/services/folder/model.ts
+++ b/src/api/services/folder/model.ts
@@ -24,6 +24,7 @@ export interface FolderBookmark {
 
 export interface Questions {
   questionId: number
+  csQuestionId: number
   projectId: number
   question: string
   repoName: string

--- a/src/app/(after)/bookmark/page.tsx
+++ b/src/app/(after)/bookmark/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { folderInfo, folderQuestions } from '@/api/services/folder/queries'
-import { QuestionList } from '@/components/Bookmark'
-import { FolderList } from '@/components/Bookmark/FolderList'
+import { folderInfo } from '@/api/services/folder/queries'
+import { QuestionList, FolderList } from '@/components/Bookmark'
 import { useDelayedLoading } from '@/hooks/useDelayedLoading'
 import { useCallback, useEffect, useState } from 'react'
 

--- a/src/components/Bookmark/FolderList.tsx
+++ b/src/components/Bookmark/FolderList.tsx
@@ -26,28 +26,16 @@ export const FolderList = ({
     <section className="flex min-w-64 flex-col gap-3 text-slate-800">
       <h2 className="text-xl font-semibold">폴더 관리</h2>
       <div className="flex flex-col gap-5">
-        <h3 className="pb-3 text-[18px] leading-5 font-medium">
-          폴더 목록
-        </h3>
+        <h3 className="pb-3 text-[18px] leading-5 font-medium">폴더 목록</h3>
         <div className="flex flex-col gap-2">
-          {isLoading
-            ? Array.from({ length: folders.length }).map((_, i) => (
-                <div
-                  key={i}
-                  className="flex animate-pulse items-center gap-4 rounded-md bg-slate-100 p-3"
-                >
-                  <div className="h-4 w-4 rounded-full bg-slate-300" />
-                  <div className="h-4 flex-1 rounded bg-slate-200" />
-                </div>
-              ))
-            : folders.map((folder) => (
-                <FolderItem
-                  key={folder.folderId}
-                  folder={folder}
-                  isSelected={folderId === folder.folderId}
-                  onSelect={handleSelect}
-                />
-              ))}
+          {folders.map((folder) => (
+            <FolderItem
+              key={folder.folderId}
+              folder={folder}
+              isSelected={folderId === folder.folderId}
+              onSelect={handleSelect}
+            />
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/Bookmark/QuestionItem.tsx
+++ b/src/components/Bookmark/QuestionItem.tsx
@@ -10,11 +10,11 @@ import { QuestionStatus } from '@/api/types/common'
 
 interface QuestionItemProps {
   question: Questions
-  onBookmarkCancel: (questionId: number) => void // 클릭된 질문을 식별하는 ID를 전달
+  onBookmarkClick: () => void
 }
 
 export const QuestionItem = React.memo(
-  ({ question, onBookmarkCancel }: QuestionItemProps) => {
+  ({ question, onBookmarkClick }: QuestionItemProps) => {
     const statusStyle = clsx('rounded-full px-3 py-1 text-sm font-medium', {
       'bg-green-50 text-green-500':
         question.questionStatus === ('DONE' as QuestionStatus),
@@ -28,9 +28,15 @@ export const QuestionItem = React.memo(
 
     //질문 클릭 시 질문 기록으로 이동
     const handleClick = () => {
-      router.push(
-        `/project/${question.projectId}?tab=question-history&questionId=${question.questionId}`,
-      )
+      if (question.projectId && question.questionId) {
+        // 프로젝트 기반 질문일 경우
+        router.push(
+          `/project/${question.projectId}?tab=question-history&questionId=${question.questionId}`,
+        )
+      } else {
+        // CS 질문일 경우
+        router.push(`/cs/solve/${question.csQuestionId}?tab=solution`)
+      }
     }
 
     return (
@@ -40,11 +46,13 @@ export const QuestionItem = React.memo(
       >
         <div className="flex flex-col gap-1">
           <p className="line-clamp-2 text-[16px]">{question.question}</p>
-          <span className="flex items-center gap-1 text-sm">
-            {question.repoName} /
-            <FileText size={16} className="text-blue-600" />
-            <span className="text-slate-500">{question.fileName}</span>
-          </span>
+          {question.repoName && question.fileName && (
+            <span className="flex items-center gap-1 text-sm">
+              {question.repoName} /
+              <FileText size={16} className="text-blue-600" />
+              <span className="text-slate-500">{question.fileName}</span>
+            </span>
+          )}
         </div>
         <div>
           <span className="rounded-full bg-blue-100 px-2 py-1 text-sm text-blue-600">
@@ -56,16 +64,22 @@ export const QuestionItem = React.memo(
             {mapStatus(question.questionStatus)}
           </span>
         </div>
-        <BookmarkIcon
-          size={20}
+        <button
+          type="button"
+          aria-label={isBookmarked ? '북마크 해제' : '북마크 추가'}
+          aria-pressed={isBookmarked}
           onClick={(e) => {
-            e.stopPropagation() // ✅ 상위 div의 onClick(페이지 이동)을 막음
-            onBookmarkCancel(question.questionId)
+            e.stopPropagation()
+            onBookmarkClick()
           }}
-          className={`cursor-pointer transition duration-200 ${
-            isBookmarked ? 'fill-current text-yellow-400' : 'text-slate-500'
-          } hover:text-yellow-300`} // 북마크 상태에 따라 색상/아이콘 채우기 처리
-        />
+        >
+          <BookmarkIcon
+            size={20}
+            className={`cursor-pointer transition duration-200 ${
+              isBookmarked ? 'fill-current text-yellow-400' : 'text-slate-500'
+            } hover:text-yellow-300`} // 북마크 상태에 따라 색상/아이콘 채우기 처리
+          />
+        </button>
       </div>
     )
   },

--- a/src/components/CS/CSSolve.tsx
+++ b/src/components/CS/CSSolve.tsx
@@ -10,14 +10,20 @@ import { Loader2 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { AnswerList } from './AnswerList'
 import { FeedbackList } from './FeedbackList'
+import { useSearchParams } from 'next/navigation'
 
 interface CSSolveProps {
   question: CSQuestionDetail
 }
 
 export const CSSolve = ({ question }: CSSolveProps) => {
+  const searchParmas = useSearchParams()
+  const tabFromUrl = searchParmas.get('tab') as 'challenge' | 'solution' | null
+
   const [answer, setAnswer] = useState('')
-  const [tab, setTab] = useState<'challenge' | 'solution'>('challenge')
+  const [tab, setTab] = useState<'challenge' | 'solution'>(
+    tabFromUrl ?? 'challenge',
+  )
   const feedbackRef = useRef<HTMLDivElement>(null)
   const queryClient = useQueryClient()
 


### PR DESCRIPTION
## 📌 관련 이슈

* 이슈 번호: 

## 💡 작업 내용

<!-- 이번 PR에서 작업한 내용을 자세히 설명해주세요 -->

* 폴더 내 북마크 질문 리스트 UI에서 `projectId`과 `csQuestionId`을 구분해 처리
* `QuestionItem` 클릭 시 각각의 질문 유형에 따라 알맞은 경로로 이동되도록 수정
* `repoName`, `fileName`이 존재하지 않는 경우 해당 정보가 보이지 않도록 조건부 렌더링
* `isBookmarked: true`인 상태로 고정된 북마크 취소 기능을 `useBookmarkHandler` 훅을 사용해 통일
* React key 충돌 방지를 위해 `questionId`와 `csQuestionId`를 조합하여 고유 key 생성

## ✨ 주요 변경점

* [x] `QuestionItem` 내 클릭 시 경로 분기 (`/project` vs `/cs/solve`)
* [x] `repoName` / `fileName` 조건부 UI 렌더링 처리
* [x] 북마크 취소 로직을 `useBookmarkHandler` 훅으로 통합
* [x] key 충돌 방지를 위한 고유 key 지정 (`project-xxx`, `cs-xxx`)
* [x] `aria-pressed` 속성 추가로 접근성 개선

## ✅ 셀프 체크리스트

* [x] PR 제목을 형식에 맞게 작성했나요?
* [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
* [x] 이슈는 close 했나요?
* [x] Reviewers, Labels를 등록했나요?
* [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
* [x] 테스트는 잘 통과했나요?
* [x] 불필요한 코드는 제거했나요?
