### PR TITLE
Fix/user

### DIFF
--- a/src/api/types/common.ts
+++ b/src/api/types/common.ts
@@ -1,8 +1,7 @@
 export enum Stack {
   프론트엔드 = 'FRONTEND',
   백엔드 = 'BACKEND',
-  데이터베이스 = 'DB',
-  알고리즘 = 'ALGORITHM',
+  모바일 = 'ANDROID_IOS',
 }
 
 export enum QuestionStatus {

--- a/src/app/(before)/token/page.tsx
+++ b/src/app/(before)/token/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuthStore } from '@/store/authStore'
+import Cookies from 'js-cookie'
 
 export default function AuthCallback() {
   return (
@@ -18,26 +19,40 @@ const AuthCallbackContent = () => {
   const { setAccessToken, setRole, setRefreshToken, setGithubAccessToken } =
     useAuthStore()
 
-  const access = searchParams.get('accessToken')
-  const refresh = searchParams.get('refreshToken')
-  const githubAccess = searchParams.get('githubAccessToken')
-  const role =
-    (searchParams.get('role') as 'GUEST' | 'USER' | 'WITHDRAWN') || 'GUEST'
+  const env = process.env.NEXT_PUBLIC_ENV || 'dev'
 
   useEffect(() => {
-    if (access && refresh && githubAccess) {
-      setAccessToken(access)
-      setRefreshToken(refresh)
-      setGithubAccessToken(githubAccess)
-      setRole(role)
+    const role =
+      (searchParams.get('role') as 'GUEST' | 'USER' | 'WITHDRAWN') || 'GUEST'
 
-      if (role === 'GUEST' || role === 'WITHDRAWN') {
-        router.replace('/signup')
-      } else if (role === 'USER') {
-        router.replace('/dashboard')
+    if (env === 'dev') {
+      const access = searchParams.get('accessToken')
+      const refresh = searchParams.get('refreshToken')
+      const githubAccess = searchParams.get('githubAccessToken')
+
+      if (access && refresh && githubAccess) {
+        setAccessToken(access)
+        setRefreshToken(refresh)
+        setGithubAccessToken(githubAccess)
+        setRole(role)
+
+        router.replace(role === 'USER' ? '/dashboard' : '/signup')
+      }
+    } else {
+      const access = Cookies.get('accessToken')
+      const refresh = Cookies.get('refreshToken')
+      const githubAccess = Cookies.get('githubAccessToken')
+
+      if (access && refresh && githubAccess) {
+        setAccessToken(access)
+        setRefreshToken(refresh)
+        setGithubAccessToken(githubAccess)
+        setRole(role)
+
+        router.replace(role === 'USER' ? '/dashboard' : '/signup')
       }
     }
-  }, [access, refresh, role, router, setRefreshToken])
+  }, [env, searchParams, router])
 
   return null
 }

--- a/src/components/EditForm/EditForm.tsx
+++ b/src/components/EditForm/EditForm.tsx
@@ -19,8 +19,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Stack } from '@/api/types/common'
 
 const notificationOptions = [
-  { value: 'agree', label: '알림 허용' },
-  { value: 'deny', label: '알림 거부' },
+  { value: true, label: '알림 허용' },
+  { value: false, label: '알림 거부' },
 ]
 
 const techStackOptions = Object.keys(Stack).map((key) => ({
@@ -33,22 +33,26 @@ export const EditForm = () => {
   const queryClient = useQueryClient()
   const { clearAuth } = useAuthStore()
 
-  const { data: user } = useGetQuery<UserResponse>(['user'], '/user/info')
+  const { data: user } = useGetQuery<UserResponse>(['user'], '/user/info', {
+    refetchOnMount: true,
+  })
 
   const form = useForm<z.infer<typeof SignupSchema>>({
     resolver: zodResolver(SignupSchema),
     defaultValues: {
       email: '',
       stackNames: [],
-      notification: 'agree',
+      notification: true,
     },
   })
 
   useEffect(() => {
     if (user) {
-      form.setValue('email', user.result.email)
-      form.setValue('stackNames', user.result.stackNames)
-      form.setValue('notification', user.result.notification ? 'agree' : 'deny')
+      form.reset({
+        email: user.result.email,
+        stackNames: user.result.stackNames,
+        notification: user.result.notification,
+      })
     }
   }, [user])
 
@@ -56,9 +60,9 @@ export const EditForm = () => {
     '/user/info',
     {
       onSuccess: () => {
-        router.push('/dashboard')
 
         queryClient.invalidateQueries({ queryKey: ['user'] })
+        router.push('/dashboard')
       },
     },
   )
@@ -68,7 +72,7 @@ export const EditForm = () => {
 
     const updatedUser: User = {
       ...data,
-      notification: data.notification === 'agree',
+      notification: data.notification,
     }
 
     mutate(updatedUser)

--- a/src/components/Form/RadioGroup.tsx
+++ b/src/components/Form/RadioGroup.tsx
@@ -12,7 +12,7 @@ interface RadioGroupFieldProps {
   name: string
   label: string
   description?: string
-  options: { value: string; label: string }[]
+  options: { value: boolean; label: string }[]
 }
 
 export function RadioGroupField({
@@ -32,16 +32,16 @@ export function RadioGroupField({
           {description && <FormDescription>{description}</FormDescription>}
           <FormControl className="flex items-center justify-between px-[106px] py-[14px]">
             <RadioGroup
-              onValueChange={field.onChange}
-              defaultValue={field.value}
+              onValueChange={(val) => field.onChange(val === 'true')}
+              value={String(field.value)}
             >
               {options.map((option) => (
                 <FormItem
-                  key={option.value}
+                  key={String(option.value)}
                   className="flex items-center gap-2"
                 >
                   <FormControl>
-                    <RadioGroupItem value={option.value} />
+                    <RadioGroupItem value={String(option.value)} />
                   </FormControl>
                   <FormLabel className="font-normal">{option.label}</FormLabel>
                 </FormItem>

--- a/src/components/SignupForm/SignupForm.tsx
+++ b/src/components/SignupForm/SignupForm.tsx
@@ -18,8 +18,8 @@ import { Loader2 } from 'lucide-react'
 import { Stack } from '@/api/types/common'
 
 const notificationOptions = [
-  { value: 'agree', label: '알림 허용' },
-  { value: 'deny', label: '알림 거부' },
+  { value: true, label: '알림 허용' },
+  { value: false, label: '알림 거부' },
 ]
 
 export default function SignupForm() {
@@ -29,7 +29,7 @@ export default function SignupForm() {
     defaultValues: {
       email: '',
       stackNames: [],
-      notification: 'agree',
+      notification: true,
     },
   })
 
@@ -51,7 +51,7 @@ export default function SignupForm() {
   const onSubmit = async (data: z.infer<typeof SignupSchema>) => {
     const user: User = {
       ...data,
-      notification: data.notification === 'agree',
+      notification: data.notification,
     }
 
     mutate(user)

--- a/src/hooks/useValid.tsx
+++ b/src/hooks/useValid.tsx
@@ -1,13 +1,25 @@
 import { z } from 'zod'
 
 //이메일
-const emailField = z.string().email()
+const emailField = z
+  .string({
+    required_error: '이메일을 입력해주세요',
+    invalid_type_error: '이메일 형식이 아닙니다',
+  })
+  .email('올바른 이메일 형식이 아닙니다.')
 
 //기술 스택
-const stacksField = z.array(z.string()).min(1)
+const stacksField = z
+  .array(z.string(), {
+    required_error: '기술 스택을 선택해주세요',
+  })
+  .min(1, '기술 스택을 한 개 이상 선택해주세요.')
 
 //알림 설정
-const notificationOptions = z.enum(['agree', 'deny'])
+const notificationOptions = z.boolean({
+  required_error: '알림 수신 여부를 선택해주세요.',
+  invalid_type_error: '알림 수신 여부를 선택해주세요.',
+})
 
 /**
  * 프로젝트 폼 유효성 검증을 위한 Zod 스키마


### PR DESCRIPTION
## 📌 관련 이슈

* 이슈 번호:
  \#24 (기술 스택 enum 수정)
  \#40 (알림 설정 및 로그인 토큰 처리 개선)


## 💡 작업 내용

* 기술 스택 enum 구조를 통일감 있게 수정했습니다.
* 알림 설정을 string → boolean 기반으로 리팩토링하고, 라디오 버튼 입력 방식도 이에 맞게 수정했습니다.
* 로그인 후 토큰 처리 로직을 dev/prod 환경에 따라 분기하도록 개선했습니다.
  dev 환경에서는 URL 쿼리, prod 환경에서는 쿠키 기반으로 저장되며, `useAuthStore`를 통해 상태 및 쿠키를 동기화합니다.

## ✨ 주요 변경점

* [x] 기술 스택 `Stack` enum을 key-value 구조로 통일
* [x] 알림 설정 필드를 boolean으로 전환 및 UI 라디오 그룹 동기화
* [x] `AuthCallback`에서 dev/prod 환경에 따른 토큰 처리 분기 추가


## ✅ 셀프 체크리스트

* [x] PR 제목을 형식에 맞게 작성했나요?
* [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
* [x] 이슈는 close 했나요? 
* [x] Reviewers, Labels를 등록했나요?
* [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
* [x] 테스트는 잘 통과했나요?
* [x] 불필요한 코드는 제거했나요?
