### PR TITLE
Feat/user activity

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,7 @@
 // =============== 사용자 (User) ===============
 // 타입
 export type { User, UserResponse } from '@/api/services/user/model'
-export { useUserJoin, useUserEdit } from '@/api/services/user/queries'
+export { useUserJoin, useUserEdit, useUserActivity } from '@/api/services/user/queries'
 
 // =============== 프로젝트 (Project) ===============
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,12 @@
 // =============== 사용자 (User) ===============
 // 타입
 export type { User, UserResponse } from '@/api/services/user/model'
-export { useUserJoin, useUserEdit, useUserActivity } from '@/api/services/user/queries'
+export {
+  useUserJoin,
+  useUserEdit,
+  useUserActivity,
+  useRefreshAccessToken,
+} from '@/api/services/user/queries'
 
 // =============== 프로젝트 (Project) ===============
 

--- a/src/api/lib/fetcher.ts
+++ b/src/api/lib/fetcher.ts
@@ -11,7 +11,7 @@ export const fetcher = async <T>(
   options: RequestInit = {},
   retry = true,
 ): Promise<T> => {
-  const { accessToken, refreshToken, setAccessToken, clearAuth } =
+  const { accessToken, refreshToken, role, setAccessToken, clearAuth } =
     useAuthStore.getState()
 
   const fetchRequest = async (token: string | null): Promise<T> => {
@@ -24,21 +24,24 @@ export const fetcher = async <T>(
       },
     })
 
-    // 🔹 인증 실패 시 토큰 재발급 시도
+    // 🔁 accessToken이 만료되었거나 유효하지 않은 경우
     if (response.status === 401 || response.status === 403) {
       if (!retry) {
-        // 이미 재시도 한 번 했는데도 실패했다면, 로그인 해제
         clearAuth()
         throw new Error('인증이 만료되었습니다. 다시 로그인해 주세요.')
       }
 
-      // refreshToken 없으면 그냥 종료
+      // ✅ GUEST 유저는 재발급 시도 금지
+      if (role === 'GUEST') {
+        throw new Error('GUEST 유저는 토큰 재발급 대상이 아닙니다.')
+      }
+
+      // refreshToken 없으면 그냥 로그아웃
       if (!refreshToken) {
         clearAuth()
         throw new Error('토큰이 만료되었습니다. 다시 로그인해 주세요.')
       }
 
-      // 🔁 accessToken 재발급 시도
       const refreshResponse = await fetch('/api/user/refresh', {
         method: 'POST',
         headers: {
@@ -59,10 +62,10 @@ export const fetcher = async <T>(
         throw new Error('토큰 재발급 실패. 다시 로그인해 주세요.')
       }
 
-      // 🆕 새 accessToken 저장
+      // 🔄 새 accessToken 저장
       setAccessToken(data.result)
 
-      // ✅ 한 번만 재시도
+      // ✅ 단 한 번만 재시도
       return await fetcher<T>(url, options, false)
     }
 

--- a/src/api/lib/fetcher.ts
+++ b/src/api/lib/fetcher.ts
@@ -89,24 +89,31 @@ export const useGetQuery = <T>(
   })
 }
 
-export const usePostMutation = <T, V>(
+export const usePostMutation = <T, V = void>(
   url: string,
   options?: UseMutationOptions<T, Error, V>,
 ) => {
   return useMutation<T, Error, V>({
     mutationFn: (data: V) =>
-      fetcher<T>(url, { method: 'POST', body: JSON.stringify(data) }),
+      fetcher<T>(url, {
+        method: 'POST',
+        ...(data !== undefined && { body: JSON.stringify(data) }),
+      }),
     ...options,
   })
 }
 
-export const usePutMutation = <T, V>(
+export const usePutMutation = <T, V = void>(
   url: string,
   options?: UseMutationOptions<T, Error, V>,
 ) => {
   return useMutation<T, Error, V>({
     mutationFn: (data: V) =>
-      fetcher<T>(url, { method: 'PUT', body: JSON.stringify(data) }),
+      fetcher<T>(url, {
+        method: 'PUT',
+        ...(data !== undefined &&
+          data !== null && { body: JSON.stringify(data) }),
+      }),
     ...options,
   })
 }

--- a/src/api/lib/serverFetcher.ts
+++ b/src/api/lib/serverFetcher.ts
@@ -2,18 +2,60 @@ import { cookies } from 'next/headers'
 
 export const serverFetcher = async <T>(url: string): Promise<T> => {
   const cookieStore = await cookies()
-  const accessToken = cookieStore.get('accessToken')?.value
+  let accessToken = cookieStore.get('accessToken')?.value
+  const refreshToken = cookieStore.get('refreshToken')?.value
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+  let res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
     headers: {
       'Content-Type': 'application/json',
       ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
     },
-    cache: 'no-store', // ⭐ 항상 최신 데이터
+    cache: 'no-store',
   })
 
-  if (!res.ok) {
-    throw new Error(`serverFetcher Error: ${res.status}`)
+  // accessToken 만료 시
+  if (res.status === 401 || res.status === 403) {
+    if (!refreshToken) {
+      throw new Error('SSR: RefreshToken이 없어 재발급할 수 없습니다.')
+    }
+
+    const refreshRes = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/user/refresh`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      },
+    )
+
+    if (!refreshRes.ok) {
+      throw new Error('SSR: 토큰 재발급 실패')
+    }
+
+    const refreshData = await refreshRes.json()
+    if (!refreshData.result) {
+      throw new Error('SSR: 재발급된 토큰이 없습니다')
+    }
+
+    accessToken = refreshData.result
+
+    // 재발급된 accessToken으로 요청 재시도
+    res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      cache: 'no-store',
+    })
+
+    if (!res.ok) {
+      throw new Error(`SSR 재요청 실패: ${res.status}`)
+    }
+
+    // 여기서 accessToken을 다시 클라이언트에 전달하고 싶다면,
+    // 리턴 구조를 바꿔야 함 (예: { data, accessToken } 형태로)
   }
 
   return res.json()

--- a/src/api/services/user/model.ts
+++ b/src/api/services/user/model.ts
@@ -11,3 +11,9 @@ export interface UserResponse {
   message: string
   result: User
 }
+
+export interface DefaultResponse {
+  code: number
+  message: string
+  result: null
+}

--- a/src/api/services/user/model.ts
+++ b/src/api/services/user/model.ts
@@ -17,3 +17,9 @@ export interface DefaultResponse {
   message: string
   result: null
 }
+
+export interface RefreshTokenResponse {
+  code: number
+  message: string
+  result: string
+}

--- a/src/api/services/user/queries.ts
+++ b/src/api/services/user/queries.ts
@@ -1,5 +1,5 @@
 import { usePostMutation, usePutMutation } from '@/api/lib/fetcher'
-import { User, UserResponse } from './model'
+import { DefaultResponse, User, UserResponse } from './model'
 
 export const useUserJoin = () => {
   return usePostMutation<UserResponse, User>('/user/join')
@@ -7,4 +7,8 @@ export const useUserJoin = () => {
 
 export const useUserEdit = () => {
   return usePutMutation<UserResponse, User>('/user/edit')
+}
+
+export const useUserActivity = (updateInterval = 5 * 60 * 1000) => { 
+  return usePostMutation<DefaultResponse>('/user/activity')
 }

--- a/src/api/services/user/queries.ts
+++ b/src/api/services/user/queries.ts
@@ -1,5 +1,10 @@
 import { usePostMutation, usePutMutation } from '@/api/lib/fetcher'
-import { DefaultResponse, User, UserResponse } from './model'
+import {
+  RefreshTokenResponse,
+  DefaultResponse,
+  User,
+  UserResponse,
+} from './model'
 
 export const useUserJoin = () => {
   return usePostMutation<UserResponse, User>('/user/join')
@@ -9,6 +14,10 @@ export const useUserEdit = () => {
   return usePutMutation<UserResponse, User>('/user/edit')
 }
 
-export const useUserActivity = (updateInterval = 5 * 60 * 1000) => { 
+export const useUserActivity = (updateInterval = 5 * 60 * 1000) => {
   return usePostMutation<DefaultResponse>('/user/activity')
+}
+
+export const useRefreshAccessToken = () => {
+  return usePostMutation<RefreshTokenResponse>('/user/refresh')
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,11 @@ import { MSWComponent } from '@/api/MSWComponent'
 import ReactQueryProvider from '@/providers/ReactQueryClient'
 
 import GlobalModal from '@/components/Modal/GlobalModal'
-import { AutoRefreshToken, FCMInitializer } from '@/components/Setting'
+import {
+  AutoRefreshToken,
+  FCMInitializer,
+  UserActivityTracker,
+} from '@/components/Setting'
 
 export const metadata: Metadata = {
   title: 'CoMentor',
@@ -25,6 +29,7 @@ const RootLayout = ({
             <ReactQueryProvider>
               <AutoRefreshToken />
               <FCMInitializer />
+              <UserActivityTracker />
 
               <GlobalModal />
               <header className="mx-[60px]">
@@ -38,6 +43,7 @@ const RootLayout = ({
           <ReactQueryProvider>
             <AutoRefreshToken />
             <FCMInitializer />
+            <UserActivityTracker />
 
             <GlobalModal />
             <header className="mx-[60px]">

--- a/src/components/Setting/UserActivityTracker.tsx
+++ b/src/components/Setting/UserActivityTracker.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useUserActivity } from '@/api'
+import { useAuthStore } from '@/store/authStore'
+
+const UserActivityTracker = () => {
+  const { mutate } = useUserActivity()
+  const intervalRef = useRef<NodeJS.Timeout | null>(null)
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+
+  useEffect(() => {
+    if (!isLoggedIn) return
+
+    const startInterval = () => {
+      intervalRef.current = setInterval(() => mutate(), 5 * 60 * 1000)
+    }
+
+    const clearIntervalIfExists = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+
+    const handleBeforeUnload = () => {
+      if (process.env.NEXT_PUBLIC_ENV === 'prod') {
+        const success = navigator.sendBeacon?.(
+          'https://comentor.store/api/user/activity',
+        )
+        if (success === false || success === undefined) {
+          mutate()
+        }
+      } else {
+        mutate()
+      }
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        startInterval()
+      } else {
+        clearIntervalIfExists()
+      }
+    }
+
+    if (document.visibilityState === 'visible') {
+      startInterval()
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      clearIntervalIfExists()
+    }
+  }, [mutate, isLoggedIn])
+
+  return null
+}
+
+export default UserActivityTracker

--- a/src/components/Setting/UserActivityTracker.tsx
+++ b/src/components/Setting/UserActivityTracker.tsx
@@ -12,10 +12,17 @@ const UserActivityTracker = () => {
   useEffect(() => {
     if (!isLoggedIn) return
 
-    const startInterval = () => {
-      intervalRef.current = setInterval(() => mutate(), 5 * 60 * 1000)
+    // 활동 기록 전송
+    const sendActivity = () => {
+      mutate()
     }
 
+    // 탭 활성화 시 interval 시작
+    const startInterval = () => {
+      intervalRef.current = setInterval(sendActivity, 5 * 60 * 1000)
+    }
+
+    // interval 중단
     const clearIntervalIfExists = () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current)
@@ -23,19 +30,12 @@ const UserActivityTracker = () => {
       }
     }
 
+    // 창 종료 또는 새로고침 시 활동 기록 전송 (mutate는 비동기이므로 성공 보장X)
     const handleBeforeUnload = () => {
-      if (process.env.NEXT_PUBLIC_ENV === 'prod') {
-        const success = navigator.sendBeacon?.(
-          'https://comentor.store/api/user/activity',
-        )
-        if (success === false || success === undefined) {
-          mutate()
-        }
-      } else {
-        mutate()
-      }
+      sendActivity()
     }
 
+    // 탭 비활성화 시 interval 중단
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         startInterval()
@@ -44,6 +44,7 @@ const UserActivityTracker = () => {
       }
     }
 
+    // 초기에 탭이 보이면 시작
     if (document.visibilityState === 'visible') {
       startInterval()
     }

--- a/src/components/Setting/index.ts
+++ b/src/components/Setting/index.ts
@@ -1,2 +1,3 @@
 export { default as AutoRefreshToken } from './token'
 export { default as FCMInitializer } from './FCMInitializer'
+export { default as UserActivityTracker } from './UserActivityTracker'

--- a/src/components/header/Notification/NotificationDropdown.tsx
+++ b/src/components/header/Notification/NotificationDropdown.tsx
@@ -61,7 +61,7 @@ export const NotificationDropdown = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="relative" aria-label="알림 열기">
+        <button className="relative cursor-pointer" aria-label="알림 열기">
           <Bell size={20} className="text-slate-800" />
           {hasUnread && (
             <span className="absolute -top-1 -right-1 flex h-2 w-2">

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -43,7 +43,10 @@ const Header = () => {
         </div>
 
         <div className="flex h-[33px] items-center justify-between">
-          <button className="hidden h-8 w-8 items-center justify-center gap-2.5 px-1 md:flex">
+          <button
+            aria-label="북마크"
+            className="hidden h-8 w-8 items-center justify-center gap-2.5 px-1 md:flex"
+          >
             <Bookmark
               className="h-5 w-5 cursor-pointer text-slate-800"
               onClick={() => router.push('/bookmark')}
@@ -52,10 +55,15 @@ const Header = () => {
           <div className="flex h-8 w-8 items-center justify-center gap-2.5">
             <NotificationDropdown />
           </div>
-          <button className="flex h-8 w-8 items-center justify-center gap-2.5">
+          <button
+            aria-label="마이페이지"
+            onClick={() => router.push('/user')}
+            className="flex h-8 w-8 items-center justify-center gap-2.5"
+          >
             <UserCircle className="h-5 w-5 cursor-pointer text-slate-800" />
           </button>
           <button
+            aria-label="메뉴 열기"
             className="flex h-8 w-8 items-center justify-center gap-2.5 md:hidden"
             onClick={() => setIsMenuOpen(true)}
           >

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,5 +16,10 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*', '/user/:path*', '/cs/:path*'],
+  matcher: [
+    '/dashboard/:path*',
+    '/user/:path*',
+    '/cs/:path*',
+    '/bookmark/:path*',
+  ],
 }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -13,9 +13,10 @@ interface AuthState {
   setGithubAccessToken: (token: string) => void
   setRole: (role: UserRole) => void
   clearAuth: () => void
+  isLoggedIn: () => boolean
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   accessToken: Cookies.get('accessToken') || null,
   refreshToken: Cookies.get('refreshToken') || null,
   githubAccessToken: Cookies.get('githubToken') || null,
@@ -40,7 +41,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   setGithubAccessToken: (token) => {
-    Cookies.set('githubToken', token, {
+    Cookies.set('githubAccessToken', token, {
       secure: true,
       sameSite: 'Strict',
       expires: 7, // ✅ 7일 유지
@@ -58,15 +59,19 @@ export const useAuthStore = create<AuthState>((set) => ({
     if (env === 'dev') {
       Cookies.remove('accessToken')
       Cookies.remove('refreshToken')
-      Cookies.remove('githubToken')
+      Cookies.remove('githubAccessToken')
     } else {
       const options = { path: '/', domain: '.comentor.store' }
 
       Cookies.remove('accessToken', options)
       Cookies.remove('refreshToken', options)
-      Cookies.remove('githubToken', options)
+      Cookies.remove('githubAccessToken', options)
     }
     Cookies.remove('role')
     set({ accessToken: null, refreshToken: null, role: null })
+  },
+  isLoggedIn: () => {
+    const { accessToken, role } = get()
+    return !!accessToken && role === 'USER'
   },
 }))

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -14,13 +14,28 @@ interface AuthState {
   setRole: (role: UserRole) => void
   clearAuth: () => void
   isLoggedIn: () => boolean
+  hydrate: () => void
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
   accessToken: Cookies.get('accessToken') || null,
   refreshToken: Cookies.get('refreshToken') || null,
-  githubAccessToken: Cookies.get('githubToken') || null,
-  role: (Cookies.get('role') as UserRole) || null,
+  githubAccessToken: Cookies.get('githubAccessToken') || null,
+  role: (Cookies.get('role') as UserRole) || 'GUEST',
+
+  hydrate: () => {
+    const accessToken = Cookies.get('accessToken') || null
+    const refreshToken = Cookies.get('refreshToken') || null
+    const githubAccessToken = Cookies.get('githubAccessToken') || null
+    const role = (Cookies.get('role') as UserRole) || 'GUEST'
+
+    set({
+      accessToken,
+      refreshToken,
+      githubAccessToken,
+      role,
+    })
+  },
 
   setAccessToken: (token) => {
     Cookies.set('accessToken', token, {
@@ -35,7 +50,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     Cookies.set('refreshToken', token, {
       secure: true,
       sameSite: 'Strict',
-      expires: 7, // ✅ 7일 유지
+      expires: 7,
     })
     set({ refreshToken: token })
   },
@@ -44,7 +59,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     Cookies.set('githubAccessToken', token, {
       secure: true,
       sameSite: 'Strict',
-      expires: 7, // ✅ 7일 유지
+      expires: 7,
     })
     set({ githubAccessToken: token })
   },
@@ -56,20 +71,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   clearAuth: () => {
     const env = process.env.NEXT_PUBLIC_ENV
-    if (env === 'dev') {
-      Cookies.remove('accessToken')
-      Cookies.remove('refreshToken')
-      Cookies.remove('githubAccessToken')
-    } else {
-      const options = { path: '/', domain: '.comentor.store' }
+    const cookieOptions =
+      env === 'dev' ? undefined : { path: '/', domain: '.comentor.store' }
 
-      Cookies.remove('accessToken', options)
-      Cookies.remove('refreshToken', options)
-      Cookies.remove('githubAccessToken', options)
-    }
+    Cookies.remove('accessToken', cookieOptions)
+    Cookies.remove('refreshToken', cookieOptions)
+    Cookies.remove('githubAccessToken', cookieOptions)
     Cookies.remove('role')
-    set({ accessToken: null, refreshToken: null, role: null })
+
+    set({
+      accessToken: null,
+      refreshToken: null,
+      githubAccessToken: null,
+      role: null,
+    })
   },
+
   isLoggedIn: () => {
     const { accessToken, role } = get()
     return !!accessToken && role === 'USER'


### PR DESCRIPTION
## 📌 관련 이슈

* 이슈 번호:


## 💡 작업 내용

* 사용자 활동 시간을 주기적으로 업데이트하고, 브라우저 종료 시에도 서버에 반영되도록 `UserActivityTracker` 컴포넌트 구현
* `fetcher`에서 사용자 `role`이 `'GUEST'`일 경우 불필요한 인증 오류 처리 로직 제거
* `usePostMutation`, `usePutMutation` 등 React Query 기반 커스텀 훅들이 `body` 없이도 사용 가능하도록 개선
* `Zustand` 상태 초기화를 위한 `hydrate()` 함수 정의 및 `AutoRefreshToken`에서 호출하여 로그인 상태 유지 개선

## ✨ 주요 변경점

* [x] `UserActivityTracker.tsx` 추가 및 `layout`에 등록하여 활동 시간 업데이트 기능 구현
* [x] `authStore.ts`에 `hydrate()` 함수 추가 및 로그인 상태 동기화
* [x] `fetcher.ts`에서 `accessToken`이 없고 `role`이 `'GUEST'`일 경우 401 처리 생략
* [x] `AutoRefreshToken.tsx`에서 hydrate 호출 로직 추가
* [x] `usePostMutation`, `usePutMutation` 등 커스텀 훅에서 `body`가 없을 때도 정상 작동하도록 조건 처리


## ✅ 셀프 체크리스트

* [x] PR 제목을 형식에 맞게 작성했나요?
* [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
* [x] 이슈는 close 했나요?
* [x] Reviewers, Labels를 등록했나요?
* [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
* [x] 테스트는 잘 통과했나요?
* [x] 불필요한 코드는 제거했나요?
